### PR TITLE
ER-487: Added check of reviews

### DIFF
--- a/sites/all/modules/reol_review/README.md
+++ b/sites/all/modules/reol_review/README.md
@@ -1,0 +1,10 @@
+# Reol review
+
+## Check availability of reviews
+
+Run the `'reol_review_check` to check availability of reviews, i.e. check the
+http code when `GET`'ing the actual review.
+
+```sh
+drush php-eval 'reol_review_check()'
+```

--- a/sites/all/modules/reol_review/reol_review.install
+++ b/sites/all/modules/reol_review/reol_review.install
@@ -144,6 +144,31 @@ function _reol_review_schema_2() {
 }
 
 /**
+ * Fourth schema version.
+ */
+function _reol_review_schema_3() {
+  $schema = _reol_review_schema_2();
+
+  $schema['reol_review_reviews']['fields']['http_code'] = array(
+    'description' => 'Http code from url (link).',
+    'type' => 'int',
+    'unsigned' => FALSE,
+    'not null' => FALSE,
+    'default' => NULL,
+  );
+
+  $schema['reol_review_reviews']['fields']['http_code_updated'] = array(
+    'description' => 'Http code updated time.',
+    'type' => 'int',
+    'unsigned' => TRUE,
+    'not null' => FALSE,
+    'default' => NULL,
+  );
+
+  return $schema;
+}
+
+/**
  * Create the database tables.
  */
 function reol_review_update_7101() {
@@ -182,4 +207,13 @@ function reol_review_update_7103() {
   $schema = _reol_review_schema_2();
   db_add_field('reol_review_reviews', 'title', $schema['reol_review_reviews']['fields']['title']);
   db_add_field('reol_review_reviews', 'author', $schema['reol_review_reviews']['fields']['author']);
+}
+
+/**
+ * Add http code to reviews.
+ */
+function reol_review_update_7104() {
+  $schema = _reol_review_schema_3();
+  db_add_field('reol_review_reviews', 'http_code', $schema['reol_review_reviews']['fields']['http_code']);
+  db_add_field('reol_review_reviews', 'http_code_updated', $schema['reol_review_reviews']['fields']['http_code_updated']);
 }

--- a/sites/all/modules/reol_review/reol_review.module
+++ b/sites/all/modules/reol_review/reol_review.module
@@ -107,6 +107,8 @@ function reol_review_theme(&$theme, $plugin) {
 function reol_review_get_random_reviews($type = NULL, $count = 1) {
   $query = db_select('reol_review_reviews', 'r')
     ->fields('r')
+    // Get only reviews that actually exist (when last checked).
+    ->condition('http_code', '200')
     ->condition('processed', 0, '<>')
     ->condition('ding_entity_id', '', '<>')
     ->orderRandom();
@@ -259,4 +261,48 @@ function reol_review_process_queue($rrid) {
     ))
     ->condition('rrid', $review->rrid)
     ->execute();
+}
+
+/**
+ * Check status of reviews.
+ *
+ * @param int $count
+ *   Number of reviews to process.
+ * @param string|null $updated_before
+ *   Process reviews last updated before this time.
+ */
+function reol_review_check($count = 100, $updated_before = NULL) {
+  $condition = db_or();
+  $condition->isNull('http_code');
+  if (NULL !== $updated_before) {
+    $time = strtotime($updated_before);
+    if (FALSE !== $time) {
+      $condition->condition('http_code_updated', $time, '<');
+    }
+  }
+
+  $query = db_select('reol_review_reviews', 'r')
+    ->fields('r', array('rrid', 'link'))
+    ->condition($condition)
+    ->range(0, $count);
+  $rows = $query->execute()->fetchAll();
+
+  $count = 0;
+  foreach ($rows as $row) {
+    $count++;
+
+    $url = $row->link;
+    $result = drupal_http_request($url, ['method' => 'HEAD']);
+    $code = $result->code;
+
+    echo sprintf('%04d/%04d % 8s %s %s', $count, count($rows), '#' . $row->rrid, $code, $url), PHP_EOL;
+
+    db_update('reol_review_reviews')
+      ->fields([
+        'http_code' => $code,
+        'http_code_updated' => REQUEST_TIME,
+      ])
+      ->condition('link', $row->link)
+      ->execute();
+  }
 }


### PR DESCRIPTION
About 1 in 5 (at last count) of the reviews from litteratursiden.dk do not exist anymore. To remedy this, we add a function to check the http status code of each review and only use reviews that actually exist (when last checked).

```
mysql> select http_code, count(*) from reol_review_reviews group by http_code;
+-----------+----------+
| http_code | count(*) |
+-----------+----------+
|       200 |     6681 |
|       404 |     1247 |
+-----------+----------+
3 rows in set (0.00 sec)
```