### PR TITLE
SUPPORT-2006: Fixed loop

### DIFF
--- a/sites/all/modules/reol_statistics/reol_statistics.module
+++ b/sites/all/modules/reol_statistics/reol_statistics.module
@@ -170,13 +170,13 @@ function reol_statistics_cron() {
     $month = ReolStatisticsMonth::fromInt(variable_get($varname, 201609));
 
     while (!$month->isCurrent()) {
-      $month = $month->next();
       $queue = DrupalQueue::get('statistics_backlog_processing');
       $payload = array(
         'class' => get_class($statistic),
         'month' => $month->toInt(),
       );
       $queue->createItem($payload);
+      $month = $month->next();
       variable_set($varname, $month->toInt());
     }
 


### PR DESCRIPTION
The `collect`ion of data may skip data at the end of a month†. This fixes this.

† If `cron` run daily at 08:00, say, all loans after 08:00 on the last day of the month will not be included in the collected data because we're collection from "next month" too early.