### PR TITLE
feature/DEVSUPP-81-statistics

### DIFF
--- a/sites/all/modules/reol_statistics/classes/ReolStatisticsMunicipality.php
+++ b/sites/all/modules/reol_statistics/classes/ReolStatisticsMunicipality.php
@@ -61,27 +61,11 @@ class ReolStatisticsMunicipality implements ReolStatisticsInterface, ReolStatist
       'loans' => 0,
       'users' => 0,
     );
-    // Collect loans.
+    // Collect loans and unique users.
     $query = db_select('reol_statistics_loans', 'l');
     $query->join('reol_statistics_unilogin', 'u', 'l.sid = u.sid');
     $query->fields('l', array('retailer_id'));
     $query->addExpression('COUNT(l.sid)', 'loans');
-    $query->condition('l.timestamp', array($month->getStartTimestamp(), $month->getEndTimestamp()), 'BETWEEN');
-    $query->groupBy('l.retailer_id');
-
-    foreach ($query->execute() as $row) {
-      if (!isset($data[$row->retailer_id])) {
-        $data[$row->retailer_id] = $empty + array(
-          'retailer_id' => $row->retailer_id,
-        );
-      }
-      $data[$row->retailer_id]['loans'] += $row->loans;
-    }
-
-    // Collect unique users.
-    $query = db_select('reol_statistics_loans', 'l');
-    $query->join('reol_statistics_unilogin', 'u', 'l.sid = u.sid');
-    $query->fields('l', array('retailer_id'));
     $query->addExpression('COUNT(DISTINCT l.user_hash)', 'users');
     $query->condition('l.timestamp', array($month->getStartTimestamp(), $month->getEndTimestamp()), 'BETWEEN');
     $query->groupBy('l.retailer_id');
@@ -92,6 +76,7 @@ class ReolStatisticsMunicipality implements ReolStatisticsInterface, ReolStatist
           'retailer_id' => $row->retailer_id,
         );
       }
+      $data[$row->retailer_id]['loans'] = $row->loans;
       $data[$row->retailer_id]['users'] = $row->users;
     }
 

--- a/sites/all/modules/reol_statistics/classes/ReolStatisticsMunicipalityRank.php
+++ b/sites/all/modules/reol_statistics/classes/ReolStatisticsMunicipalityRank.php
@@ -92,7 +92,7 @@ class ReolStatisticsMunicipalityRank implements ReolStatisticsInterface, ReolSta
     $placement = 1;
     foreach ($munis as $muni) {
       foreach ($muni as $row) {
-        $muni[0]->placement = $placement;
+        $row->placement = $placement;
       }
       $placement++;
     }

--- a/sites/all/modules/reol_statistics/reol_statistics.drush.inc
+++ b/sites/all/modules/reol_statistics/reol_statistics.drush.inc
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Implements hook_drush_command().
+ */
+function reol_statistics_drush_command() {
+  $commands['reol-statistics-crunch-isbn'] = [
+    'description' => 'Crunch data for ReolStatisticsISBN.',
+    'arguments' => [
+      'month' => 'Month to crunch (default: current month).',
+    ],
+    'examples' => [
+       'drush reol-statistics-crunch-isbn' => 'Cruch data for current month.',
+       'drush reol-statistics-crunch-isbn "previous month"' => 'Cruch data for previous month.',
+       'drush reol-statistics-crunch-isbn 2019-01' => 'Cruch data for January 2019.',
+    ],
+  ];
+
+  return $commands;
+}
+
+/**
+ * Drush command logic.
+ * drush_[COMMAND_NAME]().
+ */
+function drush_reol_statistics_crunch_isbn($month = null) {
+  $month = new \DateTime(null === $month ? 'first day of this month' : $month);
+
+  $statistic = new ReolStatisticsISBN();
+  $statistic->collect(ReolStatisticsMonth::fromInt((int)$month->format('Ym')));
+}

--- a/sites/all/modules/reol_statistics/reol_statistics.module
+++ b/sites/all/modules/reol_statistics/reol_statistics.module
@@ -163,6 +163,13 @@ function reol_statistics_cron() {
   $statistics = reol_statistics_get();
 
   foreach ($statistics as $statistic) {
+    if ($statistic instanceof ReolStatisticsISBN) {
+      // Crunching data for ReolStatisticsISBN takes too much time and must be
+      // handled by calling `drush reol-statistics-crunch-isbn` outside the
+      // Drupal cron schedule.
+      continue;
+    }
+
     $varname = 'reol_statistics_last_queued_' . get_class($statistic);
     if (reol_statistics_ensure_schema($statistic)) {
       variable_del($varname);


### PR DESCRIPTION
https://jira.itkdev.dk/projects/DEVSUPP/queues/custom/41/DEVSUPP-81

This is a (temporary) workaround for the statistics not being updated. The main issue is that `ReolStatisticsISBN::collect` takes too much time to complete (currently more than 7 minutes) and thus blocks the queue in the Drupal `cron` schedule.

With these changes `ReolStatisticsISBN` will not be queued and must be handled by a `cron` job (or similar) outside the Drupal `cron` schedule:

```
drush reol-statistics-crunch-isbn
```
