### PR TITLE
ER-618: Removed loanStatus from checklist item

### DIFF
--- a/sites/all/modules/publizon/lib/storage/PublizonChecklistItem.class.inc
+++ b/sites/all/modules/publizon/lib/storage/PublizonChecklistItem.class.inc
@@ -9,7 +9,6 @@ class PublizonChecklistItem extends Publizon {
     'creationDateUtc' => NULL,
     'title' => NULL,
     'isbn' => NULL,
-    'loanStatus' => NULL,
   );
 
   /**
@@ -32,6 +31,5 @@ class PublizonChecklistItem extends Publizon {
     $this->creationDateUtc = strtotime((string) $item->creationdateutc);
     $this->title = (string) $item->title;
     $this->isbn = (string) $item->isbn;
-    $this->loanStatus = (int) $item->loanstatus;
   }
 }


### PR DESCRIPTION
https://jira.itkdev.dk/browse/ER-618

For performance reasons, the “loanstatus” property will be removed from the pubhub service. eReolen don't use it for anything regarding checklists (“Huskelister”).