### PR TITLE
DEVSUPP-209: Fixed issue with cached availability

### DIFF
--- a/sites/all/modules/publizon/includes/publizon.availability.inc
+++ b/sites/all/modules/publizon/includes/publizon.availability.inc
@@ -55,6 +55,10 @@ function publizon_availability_items(array $local_ids) {
 
   // Whitelisted cards should not use cached responses.
   $use_cache = !in_array($card_number, variable_get('publizon_test_card_numbers', []));
+  // Others should use cached anonymous availability information.
+  if ($use_cache) {
+    $card_number = NULL;
+  }
 
   // Check cache as calls to publizon is expensive and this availability
   // function is called many time for each material displayed. When selecting


### PR DESCRIPTION
https://jira.itkdev.dk/browse/DEVSUPP-209

We may cache non-anonymous availability statuses. All cached availabily information should be anonymous.

This issue was apparently introduced in https://github.com/eReolen/base/commit/cb62f1c43b873637ce564e8932f126251a2dda94#diff-22b9646d6995bc9bc118f70f57022ea9R91.