### PR TITLE
ER-339 added a title and label for the bookicons

### DIFF
--- a/sites/all/modules/reol_frontend/reol_frontend.module
+++ b/sites/all/modules/reol_frontend/reol_frontend.module
@@ -86,6 +86,7 @@ function reol_frontend_form_search_block_form_alter(&$form, &$form_state, $form_
  */
 function theme_reol_overlay_icons($variables) {
   $spans = '';
+  $title = "Der bruges en kvote på at låne dette materiale";
 
   if (!isset($variables['classes']) || !is_array($variables['classes'])) {
     $variables['classes'] = array();
@@ -93,7 +94,11 @@ function theme_reol_overlay_icons($variables) {
   $variables['classes'][] = 'overlay-icons';
 
   foreach (array_filter($variables['icons']) as $icon) {
-    $spans .= '<span class="icon ' . $icon . '"></span>';
+    if (in_array('no-quota', $variables['classes'])) {
+      $quota .= " no-quota";
+      $title = "Der bruges ikke en kvote på at låne dette materiale";
+    }
+    $spans .= '<span title="' . $title . '" aria-labelledby="' . $icon . $quota . '" class="icon ' . $icon . '"></span>';
   }
 
   if (!$spans) {
@@ -213,6 +218,7 @@ function reol_frontend_views_query_alter(&$view, &$query) {
  *   HTML for the icons, or an empty string.
  */
 function reol_frontend_ding_entity_icons(DingEntity $ding_entity) {
+  
   if (!isset($ding_entity->reol_no_icons)) {
     $classes = array();
     $icons = array();

--- a/sites/all/themes/orwell/sass/component/_overlay-icons.scss
+++ b/sites/all/themes/orwell/sass/component/_overlay-icons.scss
@@ -44,8 +44,3 @@
     color: $color__link__default;
   }
 }
-
-.hidden-from-sight {
-  position: absolute;
-  top: -10000px;
-}

--- a/sites/all/themes/orwell/sass/component/_overlay-icons.scss
+++ b/sites/all/themes/orwell/sass/component/_overlay-icons.scss
@@ -1,4 +1,3 @@
-
 .ting-cover-wrapper,
 .linkbox {
   // Establish a positioning context for the type icons.
@@ -15,12 +14,12 @@
 
   .icon::before {
     @include icon;
-    padding: .5rem;
+    padding: 0.5rem;
     background-color: $color__white;
     border-radius: 50%;
     color: $color__font-gray;
     font-size: 1rem;
-    margin-left: .5rem;
+    margin-left: 0.5rem;
   }
 
   &.no-quota .icon::before {
@@ -44,4 +43,9 @@
     content: $icon__link;
     color: $color__link__default;
   }
+}
+
+.hidden-from-sight {
+  position: absolute;
+  top: -10000px;
 }

--- a/sites/all/themes/orwell/templates/layouts/reol-site-template.tpl.php
+++ b/sites/all/themes/orwell/templates/layouts/reol-site-template.tpl.php
@@ -5,19 +5,19 @@
  * Override reol default site template.
  */
 ?>
-<div id="audiobook" class="hidden-from-sight">
+<div id="audiobook" class="element-invisible element-focusable">
   Lydbog
 </div>
-<div id="link" class="hidden-from-sight">
+<div id="link" class="element-invisible element-focusable">
   Link
 </div>
-<div id="ebook" class="hidden-from-sight">
+<div id="ebook" class="element-invisible element-focusable">
   E-bog
 </div>
-<div id="podcast" class="hidden-from-sight">
+<div id="podcast" class="element-invisible element-focusable">
   Podcast
 </div>
-<div id="no-quota" class="hidden-from-sight">
+<div id="no-quota" class="element-invisible element-focusable">
   Der bruges ikke en kvote på at låne dette materiale
 </div>
 <div id="page<?php print $css_id ? " $css_id" : ''; ?>" class="<?php print $classes; ?>">

--- a/sites/all/themes/orwell/templates/layouts/reol-site-template.tpl.php
+++ b/sites/all/themes/orwell/templates/layouts/reol-site-template.tpl.php
@@ -5,6 +5,21 @@
  * Override reol default site template.
  */
 ?>
+<div id="audiobook" class="hidden-from-sight">
+  Lydbog
+</div>
+<div id="link" class="hidden-from-sight">
+  Link
+</div>
+<div id="ebook" class="hidden-from-sight">
+  E-bog
+</div>
+<div id="podcast" class="hidden-from-sight">
+  Podcast
+</div>
+<div id="no-quota" class="hidden-from-sight">
+  Der bruges ikke en kvote på at låne dette materiale
+</div>
 <div id="page<?php print $css_id ? " $css_id" : ''; ?>" class="<?php print $classes; ?>">
   <?php if (!empty($content['branding']) || !empty($content['header']) || !empty($content['navigation']) || !empty($content['top'])): ?>
     <header class="site-header">


### PR DESCRIPTION
**Label renderet i dommen**

<img width="400" alt="Screenshot 2020-05-11 at 14 07 25" src="https://user-images.githubusercontent.com/15377965/81560718-4035d700-9392-11ea-8581-35386043ad01.png">

**Titler**
<img width="400" alt="Screenshot 2020-05-11 at 14 06 59" src="https://user-images.githubusercontent.com/15377965/81560715-3f9d4080-9392-11ea-89b6-1888cd402feb.png">

<img width="400" alt="Screenshot 2020-05-11 at 14 06 54" src="https://user-images.githubusercontent.com/15377965/81560720-40ce6d80-9392-11ea-98ad-cbb838a01535.png">

Jeg har fixet det forkerte fordi jeg læse opgaven forkert, men i dette pull request har jeg altså tilføjet en aria-label, så skærmlæsere også fanger de informationer der er i ikonerne. Så har jeg tilføjet en titel, som ses ovenstående, men det kan nok godt gøres _endnu_ bedre