### PR TITLE
Hotfix/youtube videos

### DIFF
--- a/sites/all/modules/contrib/media_youtube/LICENSE.txt
+++ b/sites/all/modules/contrib/media_youtube/LICENSE.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/sites/all/modules/contrib/media_youtube/README.txt
+++ b/sites/all/modules/contrib/media_youtube/README.txt
@@ -1,0 +1,41 @@
+CONTENTS OF THIS FILE
+---------------------
+
+ * Introduction
+ * Requirements
+ * Installation
+ * Usage
+
+INTRODUCTION
+------------
+
+Current Maintainers:
+
+ * Devin Carlson <http://drupal.org/user/290182>
+
+Media: YouTube adds YouTube as a supported media provider.
+
+REQUIREMENTS
+------------
+
+Media: YouTube has one dependency.
+
+Contributed modules
+ * Media Internet - A submodule of the Media module.
+
+INSTALLATION
+------------
+
+Media: YouTube can be installed via the standard Drupal installation process
+(http://drupal.org/node/895232).
+
+USAGE
+-----
+
+Media: YouTube integrates the YouTube video-sharing service with the Media
+module to allow users to add and manage YouTube videos as they would any other
+piece of media.
+
+Internet media can be added on the Web tab of the Add file page (file/add/web).
+With Media: YouTube enabled, users can add a YouTube video by entering its URL
+or embed code.

--- a/sites/all/modules/contrib/media_youtube/includes/MediaInternetYouTubeHandler.inc
+++ b/sites/all/modules/contrib/media_youtube/includes/MediaInternetYouTubeHandler.inc
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * @file
+ * Extends the MediaInternetBaseHandler class to handle YouTube videos.
+ */
+
+/**
+ * Implementation of MediaInternetBaseHandler.
+ *
+ * @see hook_media_internet_providers().
+ */
+class MediaInternetYouTubeHandler extends MediaInternetBaseHandler {
+
+  public function parse($embedCode) {
+    $list_patterns = array(
+      '@youtube\.com/playlist[#\?].*?list=([^"#\& ]+)@i',
+      '@youtube\.com/view_play_list[#\?].*?p=([^"#\& ]+)@i',
+    );
+
+    foreach ($list_patterns as $pattern) {
+      preg_match($pattern, $embedCode, $matches);
+
+      if (isset($matches[1]) && $this->validId($matches[1], 'l')) {
+        return file_stream_wrapper_uri_normalize('youtube://l/' . $matches[1]);
+      }
+    }
+    // https://youtube.com/watch/*
+    // https://youtube.com/embed/*
+    // https://youtube.com/v/*
+    // https://youtube.com/?v=*
+    // https://youtu.be/*
+    // https://gdata.youtube.com/feeds/api/videos/*
+    $patterns = array(
+      '@youtube\.com/watch[#\?].*?v=([^"#\& ]+).*&list=([^"#\& ]+)@i',
+      '@youtu\.be/([^"#\&\? ]+)\?list=([^"#\& ]+)@i',
+      '@youtube\.com/embed/([^"#\&\? ]+)\?list=([^"#\& ]+)@i',
+      '@youtube\.com/watch[#\?].*?v=([^"#\& ]+)@i',
+      '@youtube\.com/embed/([^"#\&\? ]+)@i',
+      '@youtube\.com/v/([^"#\&\? ]+)@i',
+      '@youtube\.com/\?v=([^"#\& ]+)@i',
+      '@youtu\.be/([^"#\&\? ]+)@i',
+      '@gdata\.youtube\.com/feeds/api/videos/([^"#\&\? ]+)@i',
+    );
+
+    foreach ($patterns as $pattern) {
+      preg_match_all($pattern, $embedCode, $matches);
+      // @TODO: Parse is called often. Refactor so that valid ID is checked
+      // when a video is added, but not every time the embedCode is parsed.
+      if (isset($matches[1][0]) && $this->validId($matches[1][0])) {
+        $uri = 'youtube://v/' . $matches[1][0];
+        if (isset($matches[2][0]) && $this->validId($matches[2][0], 'l')) {
+          $uri .= '/l/' . $matches[2][0];
+        }
+        return file_stream_wrapper_uri_normalize($uri);
+      }
+    }
+  }
+
+  public function claim($embedCode) {
+    if ($this->parse($embedCode)) {
+      return TRUE;
+    }
+  }
+
+  public function getFileObject() {
+    $uri = $this->parse($this->embedCode);
+    $file = file_uri_to_object($uri, TRUE);
+
+    // Try to default the file name to the video's title.
+    if (empty($file->fid) && $info = $this->getOEmbed()) {
+      $file->filename = truncate_utf8($info['title'], 255);
+    }
+
+    return $file;
+  }
+
+  /**
+   * Returns information about the media.
+   *
+   * See http://www.oembed.com.
+   *
+   * @return
+   *   If oEmbed information is available, an array containing 'title', 'type',
+   *   'url', and other information as specified by the oEmbed standard.
+   *   Otherwise, NULL.
+   */
+  public function getOEmbed() {
+    $uri = $this->parse($this->embedCode);
+    $external_url = file_create_url($uri);
+    $oembed_url = url('https://www.youtube.com/oembed', array('query' => array('url' => $external_url, 'format' => 'json')));
+    $response = drupal_http_request($oembed_url);
+
+    if (!isset($response->error)) {
+      return drupal_json_decode($response->data);
+    }
+    else {
+      throw new Exception("Error Processing Request. (Error: {$response->code}, {$response->error})");
+      return;
+    }
+  }
+
+  /**
+   * Check if a YouTube video ID is valid.
+   *
+   * @return boolean
+   *   TRUE if the video ID is valid, or throws a
+   *   MediaInternetValidationException otherwise.
+   */
+  public function validId($id, $type = 'v') {
+    $uri = file_stream_wrapper_uri_normalize('youtube://' . $type . '/' . check_plain($id));
+    $external_url = file_create_url($uri);
+    $oembed_url = url('https://www.youtube.com/oembed', array('query' => array('url' => $external_url, 'format' => 'json')));
+    $response = drupal_http_request($oembed_url, array('method' => 'HEAD'));
+
+    if ($response->code == 401) {
+      throw new MediaInternetValidationException('Embedding has been disabled for this YouTube video.');
+    }
+    elseif ($response->code != 200) {
+      throw new MediaInternetValidationException('The YouTube video ID is invalid or the video was deleted.');
+    }
+
+    return TRUE;
+  }
+}

--- a/sites/all/modules/contrib/media_youtube/includes/MediaInternetYouTubeHandler.inc
+++ b/sites/all/modules/contrib/media_youtube/includes/MediaInternetYouTubeHandler.inc
@@ -111,7 +111,7 @@ class MediaInternetYouTubeHandler extends MediaInternetBaseHandler {
     $uri = file_stream_wrapper_uri_normalize('youtube://' . $type . '/' . check_plain($id));
     $external_url = file_create_url($uri);
     $oembed_url = url('https://www.youtube.com/oembed', array('query' => array('url' => $external_url, 'format' => 'json')));
-    $response = drupal_http_request($oembed_url, array('method' => 'HEAD'));
+    $response = drupal_http_request($oembed_url, array('method' => 'GET'));
 
     if ($response->code == 401) {
       throw new MediaInternetValidationException('Embedding has been disabled for this YouTube video.');

--- a/sites/all/modules/contrib/media_youtube/includes/MediaYouTubeStreamWrapper.inc
+++ b/sites/all/modules/contrib/media_youtube/includes/MediaYouTubeStreamWrapper.inc
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ *  @file
+ *  Extends the MediaReadOnlyStreamWrapper class to handle YouTube videos.
+ */
+
+/**
+ *  Create an instance like this:
+ *  $youtube = new MediaYouTubeStreamWrapper('youtube://v/[video-code]');
+ */
+class MediaYouTubeStreamWrapper extends MediaReadOnlyStreamWrapper {
+  protected $base_url = 'https://www.youtube.com/watch';
+
+  static function getMimeType($uri, $mapping = NULL) {
+    return 'video/youtube';
+  }
+
+  function getOriginalThumbnailPath() {
+    $parts = $this->get_parameters();
+    $thumbnail_url = 'https://img.youtube.com/vi/' . check_plain($parts['v']) . "/maxresdefault.jpg";
+    $response = drupal_http_request($thumbnail_url);
+    if ($response->code == 404) {
+      $thumbnail_url = 'https://img.youtube.com/vi/' . check_plain($parts['v']) . "/hqdefault.jpg";
+      $response = drupal_http_request($thumbnail_url);
+    }
+    if (!isset($response->error)) {
+      return $thumbnail_url;
+    }
+    elseif ($response->code == -110) {
+      throw new MediaInternetValidationException("Connection timed out.");
+    }
+    elseif ($response->code == 401) {
+      throw new MediaInternetValidationException("Embedding has been disabled for this video.");
+    }
+    elseif ($response->code == 404) {
+      return "https://s.ytimg.com/yts/img/image-hh-404-vflvCykRp.png";
+    }
+    elseif ($response->code != 200) {
+      throw new MediaInternetValidationException("The YouTube video ID is invalid or the video was deleted.");
+    }
+    else {
+      $uri = file_stream_wrapper_uri_normalize('youtube://v/' . check_plain($parts['v']));
+      $external_url = file_create_url($uri);
+      $oembed_url = url('https://www.youtube.com/oembed', array('query' => array('url' => $external_url, 'format' => 'json')));
+      $response = drupal_http_request($oembed_url);
+
+      if (!isset($response->error)) {
+        $data = drupal_json_decode($response->data);
+        return $data['thumbnail_url'];
+      }
+      else {
+        throw new Exception("Error Processing Request. (Error: {$response->code}, {$response->error})");
+        return;
+      }
+    }
+  }
+
+  function getLocalThumbnailPath() {
+    $parts = $this->get_parameters();
+    $id = array_pop($parts);
+    $local_path = file_default_scheme() . '://media-youtube/' . check_plain($id) . '.jpg';
+    if (!file_exists($local_path)) {
+      // getOriginalThumbnailPath throws an exception if there are any errors
+      // when retrieving the original thumbnail from YouTube.
+      try {
+        $dirname = drupal_dirname($local_path);
+        file_prepare_directory($dirname, FILE_CREATE_DIRECTORY | FILE_MODIFY_PERMISSIONS);
+        $response = drupal_http_request($this->getOriginalThumbnailPath());
+
+        if (!isset($response->error)) {
+          file_unmanaged_save_data($response->data, $local_path, TRUE);
+        }
+        else {
+          system_retrieve_file($this->getOriginalThumbnailPath(), $local_path, FALSE, FILE_EXISTS_REPLACE);
+        }
+      }
+      catch (Exception $e) {
+        // In the event of an endpoint error, use the mime type icon provided
+        // by the Media module.
+        $file = file_uri_to_object($this->uri);
+        $icon_dir = variable_get('media_icon_base_directory', 'public://media-icons') . '/' . variable_get('media_icon_set', 'default');
+        $local_path = file_icon_path($file, $icon_dir);
+      }
+    }
+
+    return $local_path;
+  }
+
+  /**
+   * Updates $base_url depending on whether the embed is a video or playlist.
+   */
+  function setBaseUrl($parameters) {
+    if (isset($parameters['l'])) {
+      if (!isset($parameters['v'])) {
+        $this->base_url = 'https://youtube.com/playlist';
+      }
+      $parameters['list'] = $parameters['l'];
+      unset($parameters['l']);
+    }
+    return $parameters;
+  }
+
+  /**
+   * Returns a url in the format "https://www.youtube.com/watch?v=qsPQN4MiTeE".
+   *
+   * Overrides interpolateUrl() defined in MediaReadOnlyStreamWrapper.
+   */
+  function interpolateUrl() {
+    if ($parameters = $this->get_parameters()) {
+      $parameters = $this->setBaseUrl($parameters);
+      return $this->base_url . '?' . http_build_query($parameters);
+    }
+  }
+
+}

--- a/sites/all/modules/contrib/media_youtube/includes/media_youtube.formatters.inc
+++ b/sites/all/modules/contrib/media_youtube/includes/media_youtube.formatters.inc
@@ -1,0 +1,286 @@
+<?php
+
+/**
+ * @file
+ * File formatters for YouTube videos.
+ */
+
+/**
+ * Implements hook_file_formatter_info().
+ */
+function media_youtube_file_formatter_info() {
+  $formatters['media_youtube_video'] = array(
+    'label' => t('YouTube Video'),
+    'file types' => array('video'),
+    'default settings' => array(
+      'width' => 640,
+      'height' => 390,
+      'autohide' => 2,
+      'autoplay' => FALSE,
+      'color' => 'red',
+      'enablejsapi' => FALSE,
+      'loop' => FALSE,
+      'modestbranding' => FALSE,
+      'nocookie' => FALSE,
+      'origin' => '',
+      'protocol' => 'https:',
+      'protocol_specify' => FALSE,
+      'rel' => TRUE,
+      'showinfo' => TRUE,
+      'theme' => 'dark',
+      'captions' => FALSE,
+      'controls' => FALSE,
+    ),
+    'view callback' => 'media_youtube_file_formatter_video_view',
+    'settings callback' => 'media_youtube_file_formatter_video_settings',
+    'mime types' => array('video/youtube'),
+  );
+
+  $formatters['media_youtube_image'] = array(
+    'label' => t('YouTube Preview Image'),
+    'file types' => array('video'),
+    'default settings' => array(
+      'image_style' => '',
+    ),
+    'view callback' => 'media_youtube_file_formatter_image_view',
+    'settings callback' => 'media_youtube_file_formatter_image_settings',
+    'mime types' => array('video/youtube'),
+  );
+
+  return $formatters;
+}
+
+/**
+ * Implements hook_file_formatter_FORMATTER_view().
+ */
+function media_youtube_file_formatter_video_view($file, $display, $langcode) {
+  $scheme = file_uri_scheme($file->uri);
+
+  // WYSIWYG does not yet support video inside a running editor instance.
+  if ($scheme == 'youtube' && empty($file->override['wysiwyg'])) {
+    $element = array(
+      '#theme' => 'media_youtube_video',
+      '#uri' => $file->uri,
+      '#options' => array(),
+    );
+
+    // Fake a default for attributes so the ternary doesn't choke.
+    $display['settings']['attributes'] = array();
+
+    foreach (array('width', 'height', 'autohide', 'autoplay', 'color', 'enablejsapi', 'loop', 'modestbranding', 'nocookie', 'origin', 'protocol', 'protocol_specify', 'rel', 'showinfo', 'theme', 'attributes', 'captions','controls') as $setting) {
+      $element['#options'][$setting] = isset($file->override[$setting]) ? $file->override[$setting] : $display['settings'][$setting];
+    }
+
+    return $element;
+  }
+}
+
+/**
+ * Implements hook_file_formatter_FORMATTER_settings().
+ */
+function media_youtube_file_formatter_video_settings($form, &$form_state, $settings) {
+  $element = array();
+
+  $element['width'] = array(
+    '#title' => t('Width'),
+    '#type' => 'textfield',
+    '#default_value' => $settings['width'],
+    '#element_validate' => array('_youtube_validate_video_width_and_height'),
+  );
+  $element['height'] = array(
+    '#title' => t('Height'),
+    '#type' => 'textfield',
+    '#default_value' => $settings['height'],
+    '#element_validate' => array('_youtube_validate_video_width_and_height'),
+  );
+
+  // @see https://developers.google.com/youtube/player_parameters#Parameters
+
+  // Multiple options.
+  $element['theme'] = array(
+    '#title' => t('Player theme'),
+    '#type' => 'radios',
+    '#options' => array(
+      'dark' => t('Dark'),
+      'light' => t('Light'),
+    ),
+    '#default_value' => $settings['theme'],
+  );
+  $element['color'] = array(
+    '#title' => t('Progress bar color'),
+    '#type' => 'radios',
+    '#options' => array(
+      'red' => t('Red'),
+      'white' => t('White'),
+    ),
+    '#default_value' => $settings['color'],
+  );
+  $element['autohide'] = array(
+    '#title' => t('Controls during playback'),
+    '#type' => 'radios',
+    '#options' => array(
+      '0' => t('Keep progress bar and player controls on screen while playing'),
+      '2' => t('Hide progress bar while playing'),
+      '1' => t('Hide progress bar and player controls'),
+    ),
+    '#default_value' => $settings['autohide'],
+  );
+  $element['captions'] = array(
+    '#title' => t('Captions displaying options'),
+    '#type' => 'radios',
+    '#options' => array(
+      '0' => t('Turns captions off by default'),
+      '1' => t('Turns captions on by default'),
+      '2' => t('Turns captions on and set the caption language for the video by default'),
+    ),
+    '#default_value' => $settings['captions'],
+  );
+
+  // Single Options.
+  $element['autoplay'] = array(
+    '#title' => t('Autoplay video on load'),
+    '#type' => 'checkbox',
+    '#default_value' => $settings['autoplay'],
+  );
+  $element['loop'] = array(
+    '#title' => t('Loop video'),
+    '#type' => 'checkbox',
+    '#default_value' => $settings['loop'],
+  );
+  $element['controls'] = array(
+    '#title' => t('Show Controls'),
+    '#type' => 'checkbox',
+    '#default_value' => $settings['controls'],
+  );
+
+  // Note: make sure the positive/negative language lines up with option
+  // processing in media_youtube.theme.inc.
+  $element['showinfo'] = array(
+    '#title' => t('Display video title and uploader'),
+    '#type' => 'checkbox',
+    '#default_value' => $settings['showinfo'],
+  );
+  $element['modestbranding'] = array(
+    '#title' => t('Remove YouTube logo from the control bar'),
+    '#type' => 'checkbox',
+    '#default_value' => $settings['modestbranding'],
+  );
+  $element['rel'] = array(
+    '#title' => t('Show related videos when playback ends'),
+    '#type' => 'checkbox',
+    '#default_value' => $settings['rel'],
+  );
+  $element['nocookie'] = array(
+    '#title' => t('Use privacy enhanced (no cookie) mode'),
+    '#type' => 'checkbox',
+    '#default_value' => $settings['nocookie'],
+  );
+  $element['protocol_specify'] = array(
+    '#title' => t('Specify an http protocol'),
+    '#type' => 'checkbox',
+    '#default_value' => $settings['protocol_specify'],
+    '#description' => t('An explicit protocol may be necessary for videos embedded in RSS feeds and emails. If no protocol is specified, iframes will be protocol relative.'),
+  );
+  $element['protocol'] = array(
+    '#title' => t('Iframe protocol'),
+    '#type' => 'radios',
+    '#default_value' => 'https:',
+    '#options' => array(
+      'https:' => 'https://',
+    ),
+    '#states' => array(
+      'invisible' => array(
+        ':input[name="displays[media_youtube_video][settings][protocol_specify]"]' => array('checked' => FALSE),
+      ),
+    ),
+  );
+
+  // JS api.
+  $element['enablejsapi'] = array(
+    '#title' => t('Enable the <a href="https://developers.google.com/youtube/js_api_reference">Javascript API</a>'),
+    '#type' => 'checkbox',
+    '#default_value' => $settings['enablejsapi'],
+    '#description' => 'An id in the format <code>media-youtube-{video_id}</code> will be added to each iframe.',
+  );
+  $element['origin'] = array(
+    '#title' => t('Origin'),
+    '#type' => 'textfield',
+    '#description' => t('If the Javascript API is enabled, enter your site\'s domain for added security.'),
+    '#default_value' => $settings['origin'],
+    '#states' => array(
+      'invisible' => array(
+        ':input[name="displays[media_youtube_video][settings][enablejsapi]"]' => array('checked' => FALSE),
+      ),
+    ),
+    '#element_validate' => array('_youtube_validate_jsapi_domain'),
+  );
+
+  return $element;
+}
+
+/**
+ * Validation for width and height.
+ */
+function _youtube_validate_video_width_and_height($element, &$form_state, $form) {
+  // Check if the value is a number with an optional decimal or percentage sign, or "auto".
+  if (!empty($element['#value']) && !preg_match('/^(auto|([0-9]*(\.[0-9]+)?%?))$/', $element['#value'])) {
+    form_error($element, t("The value entered for @dimension is invalid. Please insert a unitless integer for pixels, a percent, or \"auto\". Note that percent and auto may not function correctly depending on the browser and doctype.", array('@dimension' => $element['#title'])));
+  }
+}
+
+/**
+ * Validation for Js API Origin.
+ */
+function _youtube_validate_jsapi_domain ($element, &$form_state, $form) {
+  // Check if the value is a url with http/s and no trailing directories.
+  if (!empty($element['#value']) && !preg_match('/^https?\:\/\/[a-zA-Z0-9\-\.]+\.([a-zA-Z]{2,4}){1,2}$/', $element['#value'])) {
+    form_error($element, t('Please insert a valid domain in the format http://www.yourdomain.com'));
+  }
+}
+
+/**
+ * Implements hook_file_formatter_FORMATTER_view().
+ */
+function media_youtube_file_formatter_image_view($file, $display, $langcode) {
+  $scheme = file_uri_scheme($file->uri);
+  if ($scheme == 'youtube') {
+    $wrapper = file_stream_wrapper_get_instance_by_uri($file->uri);
+    $image_style = $display['settings']['image_style'];
+    $valid_image_styles = image_style_options(FALSE);
+
+    if (empty($image_style) || !isset($valid_image_styles[$image_style])) {
+      $element = array(
+        '#theme' => 'image',
+        '#path' => str_replace('http:', '', $wrapper->getLocalThumbnailPath()),
+        '#alt' => isset($file->override['attributes']['alt']) ? $file->override['attributes']['alt'] : $file->filename,
+      );
+    }
+    else {
+      $element = array(
+        '#theme' => 'image_style',
+        '#style_name' => $image_style,
+        '#path' => $wrapper->getLocalThumbnailPath(),
+        '#alt' => isset($file->override['attributes']['alt']) ? $file->override['attributes']['alt'] : $file->filename,
+      );
+    }
+
+    return $element;
+  }
+}
+
+/**
+ * Implements hook_file_formatter_FORMATTER_settings().
+ */
+function media_youtube_file_formatter_image_settings($form, &$form_state, $settings) {
+  $element = array();
+
+  $element['image_style'] = array(
+    '#title' => t('Image style'),
+    '#type' => 'select',
+    '#options' => image_style_options(FALSE),
+    '#default_value' => $settings['image_style'],
+    '#empty_option' => t('None (original image)'),
+  );
+
+  return $element;
+}

--- a/sites/all/modules/contrib/media_youtube/media_youtube.file.inc
+++ b/sites/all/modules/contrib/media_youtube/media_youtube.file.inc
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @file
+ * File hooks implemented by the Media: YouTube module.
+ */
+
+/**
+ * Implements hook_file_operations().
+ */
+function media_youtube_file_operations() {
+  $operations = array(
+    'media_youtube_refresh' => array(
+      'label' => t('Refresh YouTube information from source'),
+      'callback' => 'media_youtube_cache_clear',
+    ),
+  );
+
+  return $operations;
+}
+
+/**
+ * Clear the cached YouTube content for the selected files.
+ */
+function media_youtube_cache_clear($fids) {
+  $fids = array_keys($fids);
+  $folder = variable_get('youtube_thumb_dir');
+
+  $query = new EntityFieldQuery();
+  $results = $query
+  ->entityCondition('entity_type', 'file')
+  ->propertyCondition('uri', '%' . $folder . '%', 'LIKE')
+  ->propertyCondition('fid', $fids)
+  ->execute();
+
+  if (!empty($results)) {
+    $files = file_load_multiple(array_keys($results['file']));
+
+    foreach ($files as $file) {
+      foreach (image_styles() as $isid => $style) {
+        $path = image_style_url($isid, $file->uri);
+        if ($path) {
+          image_path_flush($path);
+        }
+      }
+      drupal_set_message(t('Refreshed thumbnail and derivatives for %filename', array('%filename' => $file->filename)));
+    }
+  }
+}

--- a/sites/all/modules/contrib/media_youtube/media_youtube.file_default_displays.inc
+++ b/sites/all/modules/contrib/media_youtube/media_youtube.file_default_displays.inc
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * @file
+ * Default display configuration for the default file types.
+ */
+
+/**
+ * Implements hook_file_default_displays().
+ */
+function media_youtube_file_default_displays() {
+  $file_displays = array();
+
+  // Media: YouTube 7.x-2.x.
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
+  $file_display->name = 'video__default__media_youtube_video';
+  $file_display->weight = 0;
+  $file_display->status = TRUE;
+  $file_display->settings = array(
+    'width' => '640',
+    'height' => '390',
+    'theme' => 'dark',
+    'color' => 'red',
+    'autohide' => '2',
+    'autoplay' => 0,
+    'loop' => 0,
+    'showinfo' => 1,
+    'modestbranding' => 0,
+    'rel' => 0,
+    'nocookie' => 0,
+    'protocol_specify' => 0,
+    'protocol' => 'https:',
+    'enablejsapi' => 0,
+    'origin' => '',
+  );
+  $file_displays['video__default__media_youtube_video'] = $file_display;
+
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
+  $file_display->name = 'video__preview__media_youtube_image';
+  $file_display->weight = 0;
+  $file_display->status = TRUE;
+  $file_display->settings = array(
+    'image_style' => 'media_thumbnail',
+  );
+  $file_displays['video__preview__media_youtube_image'] = $file_display;
+
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
+  $file_display->name = 'video__teaser__media_youtube_video';
+  $file_display->weight = 0;
+  $file_display->status = TRUE;
+  $file_display->settings = array(
+    'width' => '560',
+    'height' => '340',
+    'theme' => 'dark',
+    'color' => 'red',
+    'autohide' => '2',
+    'autoplay' => 0,
+    'loop' => 0,
+    'showinfo' => 1,
+    'modestbranding' => 0,
+    'rel' => 0,
+    'nocookie' => 0,
+    'protocol_specify' => 0,
+    'protocol' => 'https:',
+    'enablejsapi' => 0,
+    'origin' => '',
+  );
+  $file_displays['video__teaser__media_youtube_video'] = $file_display;
+
+  // Media: YouTube 7.x-1.x.
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
+  $file_display->name = 'video__media_original__media_youtube_video';
+  $file_display->weight = 0;
+  $file_display->status = TRUE;
+  $file_display->settings = array(
+    'width' => '640',
+    'height' => '390',
+    'theme' => 'dark',
+    'color' => 'red',
+    'autohide' => '2',
+    'autoplay' => 0,
+    'loop' => 0,
+    'showinfo' => 1,
+    'modestbranding' => 0,
+    'rel' => 0,
+    'nocookie' => 0,
+    'protocol_specify' => 0,
+    'protocol' => 'https:',
+    'enablejsapi' => 0,
+    'origin' => '',
+  );
+  $file_displays['video__media_original__media_youtube_video'] = $file_display;
+
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
+  $file_display->name = 'video__media_large__media_youtube_video';
+  $file_display->weight = 0;
+  $file_display->status = TRUE;
+  $file_display->settings = array(
+    'width' => '640',
+    'height' => '390',
+    'theme' => 'dark',
+    'color' => 'red',
+    'autohide' => '2',
+    'autoplay' => 0,
+    'loop' => 0,
+    'showinfo' => 1,
+    'modestbranding' => 0,
+    'rel' => 0,
+    'nocookie' => 0,
+    'protocol_specify' => 0,
+    'protocol' => 'https:',
+    'enablejsapi' => 0,
+    'origin' => '',
+  );
+  $file_displays['video__media_large__media_youtube_video'] = $file_display;
+
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
+  $file_display->name = 'video__media_small__media_youtube_video';
+  $file_display->weight = 0;
+  $file_display->status = TRUE;
+  $file_display->settings = array(
+    'width' => '560',
+    'height' => '340',
+    'theme' => 'dark',
+    'color' => 'red',
+    'autohide' => '2',
+    'autoplay' => 0,
+    'loop' => 0,
+    'showinfo' => 1,
+    'modestbranding' => 0,
+    'rel' => 0,
+    'nocookie' => 0,
+    'protocol_specify' => 0,
+    'protocol' => 'https:',
+    'enablejsapi' => 0,
+    'origin' => '',
+  );
+  $file_displays['video__media_small__media_youtube_video'] = $file_display;
+
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
+  $file_display->name = 'video__media_preview__media_youtube_image';
+  $file_display->weight = 0;
+  $file_display->status = TRUE;
+  $file_display->settings = array(
+    'image_style' => 'square_thumbnail',
+  );
+  $file_displays['video__media_preview__media_youtube_image'] = $file_display;
+
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
+  $file_display->name = 'video__media_link__file_field_file_default';
+  $file_display->weight = 0;
+  $file_display->status = TRUE;
+  $file_display->settings = '';
+  $file_displays['video__media_link__file_field_file_default'] = $file_display;
+
+  return $file_displays;
+}

--- a/sites/all/modules/contrib/media_youtube/media_youtube.info
+++ b/sites/all/modules/contrib/media_youtube/media_youtube.info
@@ -1,0 +1,18 @@
+name = Media: YouTube
+description = Adds YouTube as a supported media provider.
+package = Media
+core = 7.x
+
+dependencies[] = media_internet
+
+test_dependencies[] = media_internet (2.x)
+
+files[] = media_youtube.test
+files[] = includes/MediaYouTubeStreamWrapper.inc
+files[] = includes/MediaInternetYouTubeHandler.inc
+
+; Information added by Drupal.org packaging script on 2019-10-03
+version = "7.x-3.9"
+core = "7.x"
+project = "media_youtube"
+datestamp = "1570113188"

--- a/sites/all/modules/contrib/media_youtube/media_youtube.install
+++ b/sites/all/modules/contrib/media_youtube/media_youtube.install
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the Media: YouTube module.
+ */
+
+/**
+ * Clear style and preset caches.
+ */
+function media_youtube_update_7001() {
+  // We don't do this if we're using version 1 of Styles.
+  if (function_exists('styles_style_flush')) {
+    styles_style_flush();
+  }
+
+  return array();
+}
+
+/**
+ * Add label to Media: YouTube file style.
+ */
+function media_youtube_update_7003() {
+  return array();
+}
+
+/**
+ * Rebuild themes.
+ */
+function media_youtube_update_7004() {
+  drupal_theme_rebuild();
+  return array();
+}
+
+/**
+ * Add a large video preset and medium thumbnail.
+ */
+function media_youtube_update_7005() {
+  return array();
+}
+
+/**
+ * Add a square thumbnail preset.
+ */
+function media_youtube_update_7006() {
+  return array();
+}
+
+/**
+ * Rebuild the registry to locate class files in new location.
+ */
+function media_youtube_update_7007() {
+  registry_rebuild();
+}
+
+/**
+ * Rebuild styles presets to use camelCase.
+ */
+function media_youtube_update_7008() {
+  return array();
+}
+
+/**
+ * Change default styles presets.
+ */
+function media_youtube_update_7009() {
+  return array();
+}
+
+/**
+ * Change default styles presets.
+ */
+function media_youtube_update_7010() {
+  return array();
+}
+
+/**
+ * Add video presets based on Image styles.
+ */
+function media_youtube_update_7011() {
+  return array();
+}
+
+/**
+ * Rebuild theme and formatters.
+ */
+function media_youtube_update_7012() {
+  return array();
+}
+
+/**
+ * Add new browser for media.
+ */
+function media_youtube_update_7200() {
+  return array();
+}
+
+/**
+ * Clean up file display formatters and migrate settings.
+ */
+function media_youtube_update_7201() {
+  // Required to run file_displays_load() in update.php.
+  module_load_include('inc', 'file_entity', 'file_entity.file_api');
+
+  // Get view modes.
+  $video_view_modes = field_view_mode_settings('file', "video");
+  $video_view_modes['default'] = array('custom_settings' => TRUE);
+  foreach ($video_view_modes as $view_mode => $custom_settings) {
+
+    $formatters = file_displays_load('video', $view_mode);
+    $formatter = 'video__' . $view_mode . '__media_youtube_video';
+
+    if (isset($formatters[$formatter])) {
+
+      // Migrate chromeless=1 or controls='0' to autohide=1, showinfo=0.
+      if (isset($formatters[$formatter]->settings['chromeless'])) {
+        if ($formatters[$formatter]->settings['chromeless'] == 1) {
+          $formatters[$formatter]->settings['autohide'] = 1;
+          $formatters[$formatter]->settings['showinfo'] = 0;
+        }
+      }
+      if (isset($formatters[$formatter]->settings['controls'])) {
+        if ($formatters[$formatter]->settings['controls'] == 0) {
+          $formatters[$formatter]->settings['autohide'] = 1;
+          $formatters[$formatter]->settings['showinfo'] = 0;
+        }
+      }
+
+      // Remove deprecated settings from the exportable array.
+      foreach (array('version', 'fullscreen', 'hd', 'showsearch', 'controls', 'chromeless') as $deprecated) {
+        if (isset($formatters[$formatter]->settings[$deprecated])) {
+          unset($formatters[$formatter]->settings[$deprecated]);
+        }
+      }
+
+      // Save the ctools objects
+      $display = $formatters[$formatter];
+      file_display_save((object) $display);
+    }
+  }
+  return array();
+}
+
+/**
+ * Empty update function.
+ */
+function media_youtube_update_7202() {
+  // Code removed in response to http://drupal.org/node/1911970.
+}
+
+/**
+ * Remove obsolete variables.
+ */
+function media_youtube_update_7203() {
+  foreach (array('width', 'height', 'autohide', 'autoplay', 'color', 'enablejsapi', 'loop', 'modestbranding', 'nocookie', 'origin', 'protocol', 'protocol_specify', 'rel', 'showinfo', 'theme') as $setting) {
+    variable_del("media_youtube__{$setting}");
+  }
+}
+
+/**
+ * Update the Media YouTube browser's access check.
+ *
+ * Check your permissions; after this update the Media YouTube browser will be
+ * available to users with the "administer files" or "add media from remote
+ * sources" permissions only.
+ */
+function media_youtube_update_7204() {
+}

--- a/sites/all/modules/contrib/media_youtube/media_youtube.module
+++ b/sites/all/modules/contrib/media_youtube/media_youtube.module
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @file
+ * Provides a stream wrapper and formatters appropriate for accessing and
+ * displaying YouTube videos.
+ */
+
+// Load all YouTube file formatters.
+require_once dirname(__FILE__) . '/includes/media_youtube.formatters.inc';
+
+/**
+ * Implements hook_media_internet_providers().
+ */
+function media_youtube_media_internet_providers() {
+  return array(
+    'MediaInternetYouTubeHandler' => array(
+      'title' => t('YouTube'),
+    ),
+  );
+}
+
+/**
+ * Implements hook_stream_wrappers().
+ */
+function media_youtube_stream_wrappers() {
+  return array(
+    'youtube' => array(
+      'name' => t('YouTube videos'),
+      'class' => 'MediaYouTubeStreamWrapper',
+      'description' => t('Remote videos hosted on the YouTube video-sharing website.'),
+      'type' => STREAM_WRAPPERS_READ_VISIBLE,
+    ),
+  );
+}
+
+/**
+ * Implements hook_theme().
+ */
+function media_youtube_theme($existing, $type, $theme, $path) {
+  return array(
+    'media_youtube_video' => array(
+      'variables' => array('uri' => NULL, 'options' => array()),
+      'file' => 'media_youtube.theme.inc',
+      'path' => $path . '/themes',
+      'template' => 'media-youtube-video',
+    ),
+  );
+}
+
+/**
+ * Implements hook_media_parse().
+ *
+ * @todo This hook should be deprecated. Refactor Media module to not call it
+ * any more, since media_internet should be able to automatically route to the
+ * appropriate handler.
+ */
+function media_youtube_media_parse($embed_code) {
+  $handler = new MediaInternetYouTubeHandler($embed_code);
+  return $handler->parse($embed_code);
+}
+
+/**
+ * Implements hook_file_mimetype_mapping_alter().
+ */
+function media_youtube_file_mimetype_mapping_alter(&$mapping) {
+  $mapping['mimetypes'][] = 'video/youtube';
+}
+
+/**
+ * Implements hook_ctools_plugin_api().
+ */
+function media_youtube_ctools_plugin_api($module, $api) {
+  if ($module == 'file_entity' && $api == 'file_default_displays') {
+    return array('version' => 1);
+  }
+}

--- a/sites/all/modules/contrib/media_youtube/media_youtube.test
+++ b/sites/all/modules/contrib/media_youtube/media_youtube.test
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * @file
+ * Tests for media_youtube.module.
+ */
+
+/**
+ * Provides methods specifically for testing Media YouTube's YouTube video handling.
+ */
+class MediaYouTubeTestHelper extends MediaInternetTestHelper {
+  function setUp() {
+    // Since this is a base class for many test cases, support the same
+    // flexibility that DrupalWebTestCase::setUp() has for the modules to be
+    // passed in as either an array or a variable number of string arguments.
+    $modules = func_get_args();
+    if (isset($modules[0]) && is_array($modules[0])) {
+      $modules = $modules[0];
+    }
+    $modules[] = 'media_youtube';
+    parent::setUp($modules);
+  }
+}
+
+/**
+ * Test the MediaInternetYouTubeHandler provider.
+ */
+class MediaInternetYouTubeTestCase extends MediaYouTubeTestHelper {
+  public static function getInfo() {
+    return array(
+      'name' => 'YouTube file handler provider',
+      'description' => 'Test the YouTube handler provider.',
+      'group' => 'Media YouTube',
+    );
+  }
+
+  function setUp() {
+    parent::setUp('media_youtube_test');
+
+    // Disable the private file system which is automatically enabled by
+    // DrupalTestCase so we can test the upload wizard correctly.
+    variable_del('file_private_path');
+
+    $web_user = $this->drupalCreateUser(array('create files', 'add media from remote sources', 'edit own video files'));
+    $this->drupalLogin($web_user);
+  }
+
+  /**
+   * Tests YouTube file handler.
+   */
+  function testYouTubeFileHandling() {
+    // Step 1: Add a video file by providing a URL to the resource on YouTube.
+    $edit = array();
+    $edit['embed_code'] = 'https://www.youtube.com/watch?v=9g2U12SsRns';
+    $this->drupalPost('file/add/web', $edit, t('Next'));
+
+    // Check that the file exists in the database.
+    $fid = $this->getLastFileId();
+    $file = file_load($fid);
+    $this->assertTrue($file, t('File found in database.'));
+
+    // Check that the video file has been uploaded.
+    $this->assertRaw(t('!type %name was uploaded.', array('!type' => 'Video', '%name' => $file->filename)), t('Video file uploaded.'));
+
+    // Verify that the video formatter is used to render the full video.
+    $video_info = array(
+      'uri' => $file->uri,
+      'options' => array(
+        'width' => 640,
+        'height' => 390,
+        'autohide' => 2,
+        'autoplay' => FALSE,
+        'color' => 'red',
+        'enablejsapi' => FALSE,
+        'loop' => FALSE,
+        'modestbranding' => FALSE,
+        'nocookie' => FALSE,
+        'origin' => '',
+        'protocol' => 'https:',
+        'protocol_specify' => FALSE,
+        'rel' => FALSE,
+        'controls' => FALSE,
+        'showinfo' => TRUE,
+        'theme' => 'dark',
+        'captions' => FALSE,
+      ),
+    );
+    $default_output = theme('media_youtube_video', $video_info);
+    $this->assertRaw($default_output, 'Video displayed using the Media: YouTube Video formatter.');
+
+    // Edit the file.
+    $this->drupalGet('file/' . $file->fid . '/edit');
+
+    // Verify that the image formatter is used to render the video preview.
+    $wrapper = file_stream_wrapper_get_instance_by_uri($file->uri);
+    $image_info = array(
+      'uri' => $file->uri,
+      'style_name' => 'media_thumbnail',
+      'path' => $wrapper->getLocalThumbnailPath(),
+      'alt' => isset($file->override['attributes']['alt']) ? $file->override['attributes']['alt'] : $file->filename,
+    );
+    $default_output = theme('image_style', $image_info);
+    $this->assertRaw($default_output, 'Video displayed using the Media: YouTube Image formatter.');
+  }
+}

--- a/sites/all/modules/contrib/media_youtube/tests/includes/MediaYouTubeTestHandler.inc
+++ b/sites/all/modules/contrib/media_youtube/tests/includes/MediaYouTubeTestHandler.inc
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @file
+ * Extends the MediaInternetYouTubeHandler class to make it suitable for local testing.
+ */
+
+/**
+ * A test handler for YouTube videos.
+ *
+ * @see MediaInternetYouTubeHandler().
+ */
+class MediaYouTubeTestHandler extends MediaInternetYouTubeHandler {
+  public function getOEmbed() {
+    $uri = $this->parse($this->embedCode);
+    $external_url = file_create_url($uri);
+    $oembed_url = url('media-youtube-test/oembed', array('query' => array('url' => $external_url, 'format' => 'json'), 'absolute' => TRUE));
+    $response = drupal_http_request($oembed_url);
+
+    if (!isset($response->error)) {
+      return drupal_json_decode($response->data);
+    }
+    else {
+      throw new Exception("Error Processing Request. (Error: {$response->code}, {$response->error})");
+      return;
+    }
+  }
+
+  /**
+   * Check if a YouTube video ID is valid.
+   *
+   * @return boolean
+   *   TRUE if the video ID is valid, or throws a
+   *   MediaInternetValidationException otherwise.
+   */
+  public function validId($id, $type = 'v') {
+    $uri = file_stream_wrapper_uri_normalize('youtube://' . $type . '/' . check_plain($id));
+    $external_url = file_create_url($uri);
+    $oembed_url = url('media-youtube-test/oembed', array('query' => array('url' => $external_url, 'format' => 'json'), 'absolute' => TRUE));
+    $response = drupal_http_request($oembed_url, array('method' => 'HEAD'));
+
+    if ($response->code == 401) {
+      throw new MediaInternetValidationException('Embedding has been disabled for this YouTube video.');
+    }
+    elseif ($response->code != 200) {
+      throw new MediaInternetValidationException('The YouTube video ID is invalid or the video was deleted.');
+    }
+
+    return TRUE;
+  }
+}

--- a/sites/all/modules/contrib/media_youtube/tests/includes/MediaYouTubeTestStreamWrapper.inc
+++ b/sites/all/modules/contrib/media_youtube/tests/includes/MediaYouTubeTestStreamWrapper.inc
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Extends the MediaYouTubeStreamWrapper class to make it suitable for local testing.
+ */
+
+/**
+ *  Create an instance like this:
+ *  $youtube = new MediaYouTubeTestStreamWrapper('youtube://v/[video-code]');
+ */
+class MediaYouTubeTestStreamWrapper extends MediaYouTubeStreamWrapper {
+  function getOriginalThumbnailPath() {
+    $parts = $this->get_parameters();
+    $uri = file_stream_wrapper_uri_normalize('youtube://v/' . check_plain($parts['v']));
+    $external_url = file_create_url($uri);
+    $oembed_url = url('media-youtube-test/oembed', array('query' => array('url' => $external_url, 'format' => 'json'), 'absolute' => TRUE));
+    $response = drupal_http_request($oembed_url);
+
+    if (!isset($response->error)) {
+      $data = drupal_json_decode($response->data);
+      return $data['thumbnail_url'];
+    }
+    else {
+      throw new Exception(t('Error Processing Request. (Error: %code, %error)', array('%code' => $response->code, '%error' => $response->error)));
+    }
+  }
+}

--- a/sites/all/modules/contrib/media_youtube/tests/media_youtube_test.info
+++ b/sites/all/modules/contrib/media_youtube/tests/media_youtube_test.info
@@ -1,0 +1,15 @@
+name = Media YouTube Test
+description = Provides hooks for testing Media YouTube module functionality.
+package = Media
+core = 7.x
+dependencies[] = media_youtube
+hidden = TRUE
+
+files[] = includes/MediaYouTubeTestStreamWrapper.inc
+files[] = includes/MediaYouTubeTestHandler.inc
+
+; Information added by Drupal.org packaging script on 2019-10-03
+version = "7.x-3.9"
+core = "7.x"
+project = "media_youtube"
+datestamp = "1570113188"

--- a/sites/all/modules/contrib/media_youtube/tests/media_youtube_test.module
+++ b/sites/all/modules/contrib/media_youtube/tests/media_youtube_test.module
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @file
+ * Alters Media: YouTube video handling to make it suitable for local testing.
+ */
+
+/**
+ * Implements hook_menu().
+ */
+function media_youtube_test_menu() {
+  $items['media-youtube-test/oembed'] = array(
+    'title' => 'Drupal Goto',
+    'page callback' => 'media_youtube_test_oembed',
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+  );
+
+  return $items;
+}
+
+/**
+ * Provides a fake oEmbed endpoint for local testing.
+ */
+function media_youtube_test_oembed() {
+  $query_parameters = drupal_get_query_parameters();
+  $query = parse_url($query_parameters['url'], PHP_URL_QUERY);
+  parse_str($query, $params);
+
+  $data = array(
+    'thumbnail_url' => 'https://i.ytimg.com/vi/' . $params['v'] . '/hqdefault.jpg',
+    'thumbnail_width' => 480,
+    'author_name' => 'YouTube Help',
+    'height' => 270,
+    'provider_url' => 'https://www.youtube.com/',
+    'html' => '<iframe width="480" height="270" src="https://www.youtube.com/embed/' . $params['v'] . '?feature=oembed" frameborder="0" allowfullscreen></iframe>',
+    'thumbnail_height' => 360,
+    'title' => 'YouTube Content ID',
+    'provider_name' => 'YouTube',
+    'type' => 'video',
+    'width' => 480,
+    'version' => '1.0',
+    'author_url' => 'https://www.youtube.com/user/YouTubeHelp',
+  );
+
+  drupal_json_output($data);
+}
+
+/**
+ * Implements hook_media_internet_providers_alter().
+ */
+function media_youtube_test_media_internet_providers_alter(&$providers) {
+  $provider = $providers['MediaInternetYouTubeHandler'];
+  unset($providers['MediaInternetYouTubeHandler']);
+  $providers['MediaYouTubeTestHandler'] = $provider;
+}
+
+/**
+ * Implements hook_stream_wrappers_alter().
+ */
+function media_youtube_test_stream_wrappers_alter(&$wrappers) {
+  $wrappers['youtube']['class'] = 'MediaYouTubeTestStreamWrapper';
+}
+
+/**
+ * Implements hook_media_parse_alter().
+ */
+function media_youtube_test_media_parse_alter(&$success, $context) {
+  if ($context['module'] == 'media_youtube') {
+    $handler = new MediaYouTubeTestHandler($context['url']);
+    $success = $handler->parse($context['url']);
+  }
+}

--- a/sites/all/modules/contrib/media_youtube/themes/media-youtube-video.legacy-example.tpl.php
+++ b/sites/all/modules/contrib/media_youtube/themes/media-youtube-video.legacy-example.tpl.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @file media_youtube/themes/media-youtube-video-legacy.tpl.php
+ *
+ * Legacy markup template file for theme('media_youtube_video').
+ *
+ * Variables available:
+ *  $uri - The media uri for the YouTube video (e.g., youtube://v/xsy7x8c9).
+ *  $video_id - The unique identifier of the YouTube video (e.g., xsy7x8c9).
+ *  $id - The file entity ID (fid).
+ *  $url - The full url including query options for the Youtube iframe.
+ *  $options - An array containing the Media Youtube formatter options.
+ *  $api_id_attribute - An id attribute if the Javascript API is enabled;
+ *  otherwise NULL.
+ *  $width - The width value set in Media: Youtube file display options.
+ *  $height - The height value set in Media: Youtube file display options.
+ *
+ * IMPORTANT: This file is provided to ease the upgrade path from Media:
+ *  YouTube 7.x-1.x and 7.x-2.0-alpha2 versions by maintaining the legacy
+ *  7.x-1.x markup. The markup has been simplified and improved in the 2.0
+ *  and 2.x-dev versions of media-youtube-video.tpl.php. It is recommended
+ *  that you revise any css or javascript that requires the old markup and
+ *  then delete this file.
+ */
+
+?>
+<div class="media-youtube-outer-wrapper" id="media-youtube-<?php print $id; ?>" width="<?php print $width; ?>" height="<?php print $height; ?>">
+  <div class="media-youtube-preview-wrapper" id="<?php print $video_id . "_" . $id; ?>">
+    <iframe class="media-youtube-player" <?php print $api_id_attribute; ?>width="<?php print $width; ?>" height="<?php print $height; ?>" src="<?php print $url; ?>" frameborder="0" allowfullscreen></iframe>
+  </div>
+</div>

--- a/sites/all/modules/contrib/media_youtube/themes/media-youtube-video.tpl.php
+++ b/sites/all/modules/contrib/media_youtube/themes/media-youtube-video.tpl.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file media_youtube/themes/media-youtube-video.tpl.php
+ *
+ * Template file for theme('media_youtube_video').
+ *
+ * Variables available:
+ *  $uri - The media uri for the YouTube video (e.g., youtube://v/xsy7x8c9).
+ *  $video_id - The unique identifier of the YouTube video (e.g., xsy7x8c9).
+ *  $id - The file entity ID (fid).
+ *  $url - The full url including query options for the Youtube iframe.
+ *  $options - An array containing the Media Youtube formatter options.
+ *  $api_id_attribute - An id attribute if the Javascript API is enabled;
+ *  otherwise NULL.
+ *  $width - The width value set in Media: Youtube file display options.
+ *  $height - The height value set in Media: Youtube file display options.
+ *  $title - The Media: YouTube file's title.
+ *  $alternative_content - Text to display for browsers that don't support
+ *  iframes.
+ *
+ */
+
+?>
+<div class="<?php print $classes; ?> media-youtube-<?php print $id; ?>">
+  <iframe class="media-youtube-player" <?php print $api_id_attribute; ?>width="<?php print $width; ?>" height="<?php print $height; ?>" title="<?php print $title; ?>" src="<?php print $url; ?>" name="<?php print $title; ?>" frameborder="0" allowfullscreen><?php print $alternative_content; ?></iframe>
+</div>

--- a/sites/all/modules/contrib/media_youtube/themes/media_youtube.theme.inc
+++ b/sites/all/modules/contrib/media_youtube/themes/media_youtube.theme.inc
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * @file media_youtube/themes/media_youtube.theme.inc
+ *
+ * Theme and preprocess functions for Media: YouTube.
+ */
+
+/**
+ * Preprocess function for theme('media_youtube_video').
+ */
+function media_youtube_preprocess_media_youtube_video(&$variables) {
+  // Build the URI.
+  $wrapper = file_stream_wrapper_get_instance_by_uri($variables['uri']);
+  if ($wrapper instanceof MediaReadOnlyStreamWrapper) {
+    $parts = $wrapper->get_parameters();
+    if (isset($parts['v'])) {
+      $variables['embed_type'] = 'video';
+      $variables['video_id'] = check_plain($parts['v']);
+      $embed_path = '/embed/' . $variables['video_id'];
+    }
+    elseif (isset($parts['l'])) {
+      $variables['embed_type'] = 'playlist';
+      $variables['video_id'] = check_plain($parts['l']);
+      $embed_path = '/embed/videoseries';
+    }
+  }
+  else {
+    // This happens when stream wrappers are not yet initialized. This is
+    // normally only encountered when creating content during profile install
+    // using drush make. At that point, video_id is irrelevant anyway.
+    $variables['video_id'] = '';
+  }
+
+  // Checked existing function.
+  if(function_exists('file_uri_to_object')) {
+    // Make the file object available.
+    $file_object = file_uri_to_object($variables['uri'], TRUE);
+  }
+  else {
+    $file_object = media_youtube_file_uri_to_object($variables['uri']);
+  }
+
+  // Parse options and build the query string. Only add the option to the query
+  // array if the option value is not default. Be careful, depending on the
+  // wording in media_youtube.formatters.inc, TRUE may be query=0.
+  // @see https://developers.google.com/youtube/player_parameters#Parameters
+  $query = array();
+
+  // Make css z-index work with flash object. Must be the first parameter.
+  $query['wmode'] = 'opaque';
+
+  //YouTube video controls, on or off.
+  if (isset($variables['options']['controls'])) {
+    //on or off (TRUE/FALSE) depending on what is stored in $variables['options']['controls'].
+    $query['controls'] = $variables['options']['controls'];
+  } else {
+    //on
+    $query['controls'] = TRUE;
+  }
+  // These queries default to 0. If the option is true, set value to 1.
+  foreach (array('autoplay', 'enablejsapi', 'loop', 'modestbranding') as $option) {
+    if (isset($variables['options'][$option]) && $variables['options'][$option]) {
+      $query[$option] = 1;
+    }
+  }
+  if ($variables['options']['enablejsapi']) {
+    // Add a query ID and identical html ID if js API is set.
+    $query['playerapiid'] = drupal_html_id('media-youtube-' . $variables['video_id']);
+    $variables['api_id_attribute'] = 'id="' . $query['playerapiid'] . '" ';
+
+    // Add the origin for improved security
+    $variables['options']['origin'] ? $query['origin'] = $variables['options']['origin'] : '';
+  }
+  else {
+    $variables['api_id_attribute'] = NULL;
+  }
+
+  // Currently, loop only works with a playlist. Make fake playlist out of a
+  // single video.
+  // @see https://developers.google.com/youtube/player_parameters#loop
+  if ($variables['options']['loop']) {
+    $query['playlist'] = $variables['video_id'];
+  }
+
+  // These queries default to 1. If the option is false, set value to 0.
+  foreach (array('rel', 'showinfo') as $option) {
+    if (!$variables['options'][$option]) {
+      $query[$option] = 0;
+    }
+  }
+
+  // These queries default to 1. Option wording is reversed, so if the option
+  // is true, set value to 0.
+  // (None right now.)
+
+  // Strings.
+  if ($variables['options']['theme'] != 'dark') {
+    $query['theme'] = $variables['options']['theme'];
+  }
+  if ($variables['options']['color'] != 'red') {
+    $query['color'] = $variables['options']['color'];
+  }
+  if ($variables['options']['autohide'] != '2') {
+    $query['autohide'] = $variables['options']['autohide'];
+  }
+  if ($variables['options']['captions'] > '0') {
+    // Add captions parameters to the query.
+    $query['cc_load_policy'] = '1';
+    if ($variables['options']['captions'] > '1') {
+      global $language;
+      // We can specify a default language for captions.
+      if ($language->language != LANGUAGE_NONE) {
+        $query['cc_lang_pref'] = $language->language;
+      }
+    }
+  }
+
+  if ($variables['options']['protocol_specify']) {
+    $protocol = $variables['options']['protocol'];
+  }
+  else {
+    $protocol = 'https:';
+  }
+
+  // Non-query options.
+  if ($variables['options']['nocookie']) {
+    $url_base = 'youtube-nocookie.com';
+  }
+  else {
+    $url_base = 'youtube.com';
+  }
+
+  // Add some options as their own template variables.
+  foreach (array('width', 'height') as $theme_var) {
+    $variables[$theme_var] = $variables['options'][$theme_var];
+  }
+
+  // Do something useful with the overridden attributes from the file
+  // object. We ignore alt and style for now.
+  if (isset($variables['options']['attributes']['class'])) {
+    if (is_array($variables['options']['attributes']['class'])) {
+      $variables['classes_array'] = array_merge($variables['classes_array'], $variables['options']['attributes']['class']);
+    }
+    else {
+      // Provide nominal support for Media 1.x.
+      $variables['classes_array'][] = $variables['options']['attributes']['class'];
+    }
+  }
+
+  // Add template variables for accessibility.
+  $variables['title'] = check_plain($file_object->filename);
+  // @TODO: Find an easy/ not too expensive way to get the YouTube description
+  // to use for the alternative content.
+  $variables['alternative_content'] = t('Video of @title', array('@title' => $variables['title']));
+
+  if (isset($parts['l'])) {
+    $query['list'] = $parts['l'];
+  }
+  // Build the iframe URL with options query string.
+  $variables['url'] = url($protocol . '//www.' . $url_base . $embed_path, array('query' => $query, 'external' => TRUE));
+}
+
+/**
+ * Helping function.
+ */
+function media_youtube_file_uri_to_object($uri) {
+  $uri = file_stream_wrapper_uri_normalize($uri);
+  $files = entity_load('file', FALSE, array('uri' => $uri));
+  $file = !empty($files) ? reset($files) : FALSE;
+  if (!$file) {
+    global $user;
+    $file = new stdClass();
+    $file->uid = $user->uid;
+    $file->filename = basename($uri);
+    $file->uri = $uri;
+    $file->filemime = file_get_mimetype($uri);
+    // This is gagged because some uris will not support it.
+    $file->filesize = @filesize($uri);
+    $file->timestamp = REQUEST_TIME;
+    $file->status = FILE_STATUS_PERMANENT;
+  }
+  return $file;
+}


### PR DESCRIPTION
* Updates the YouTube media module to 3.9 (YouTube doesn't support `http` anymore)
* Patches the module to use `GET` instead af `HEAD` (apparently YouTube doesn't support `HEAD` anymore)
