### PR TITLE
ER-1072: Added new prevent unpublish module

### DIFF
--- a/sites/all/modules/reol_prevent_unpublish/includes/reol_prevent_unpublish.admin.inc
+++ b/sites/all/modules/reol_prevent_unpublish/includes/reol_prevent_unpublish.admin.inc
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * Settings for prevent unpublish module.
+ */
+
+/**
+ * Administrative settings form.
+ *
+ * @param array $form
+ *   The form input.
+ * @param array $form_state
+ *   The state of the form.
+ *
+ * @return array
+ *   The finished form.
+ */
+function reol_prevent_unpublish_settings_form(array $form, array &$form_state) {
+  $form = [];
+
+  $form['wrapper'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Settings'),
+  ];
+
+  $form['wrapper']['reol_prevent_unpublish_nid'] = [
+    '#type' => 'textfield',
+    '#title' => t('Node identifiers'),
+    '#description' => t('Comma separated list of node nid that should never be unpublished.'),
+    '#default_value' => variable_get('reol_prevent_unpublish_nid', ''),
+  ];
+
+  return system_settings_form($form);
+}

--- a/sites/all/modules/reol_prevent_unpublish/reol_prevent_unpublish.info
+++ b/sites/all/modules/reol_prevent_unpublish/reol_prevent_unpublish.info
@@ -1,0 +1,4 @@
+name = eReolen prevent unpublish
+description = Prevent unpublishing selected content
+core = 7.x
+package = eReolen shared

--- a/sites/all/modules/reol_prevent_unpublish/reol_prevent_unpublish.install
+++ b/sites/all/modules/reol_prevent_unpublish/reol_prevent_unpublish.install
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Handle module install.
+ */
+
+/**
+ * Implements hook_install().
+ *
+ * Set module weight to ensure node status value is set in this module as last.
+ */
+function reol_prevent_unpublish_install() {
+  db_update('system')
+    ->fields(array('weight' => 100))
+    ->condition('name', 'reol_prevent_unpublish', '=')
+    ->execute();
+}

--- a/sites/all/modules/reol_prevent_unpublish/reol_prevent_unpublish.module
+++ b/sites/all/modules/reol_prevent_unpublish/reol_prevent_unpublish.module
@@ -29,8 +29,7 @@ function reol_prevent_unpublish_menu() {
  */
 function reol_prevent_unpublish_node_presave($node) {
   if (0 === $node->status) {
-    $nids = array_map('trim', explode(',', variable_get('reol_prevent_unpublish_nid', '')));
-    if (in_array($node->nid, $nids)) {
+    if (_reol_prevent_unpublish_is_protected($node->nid)) {
       // Nid is found in array, so publish it.
       $node->status = 1;
     }
@@ -44,10 +43,27 @@ function reol_prevent_unpublish_node_presave($node) {
  */
 function reol_prevent_unpublish_form_alter(&$form, &$form_state, $form_id) {
   if (strpos($form_id, '_node_form') !== FALSE) {
-    $nids = array_map('trim', explode(',', variable_get('reol_prevent_unpublish_nid', '')));
-    if (isset($form['nid']['#value']) && in_array($form['nid']['#value'], $nids)) {
+    if (isset($form['nid']['#value']) && _reol_prevent_unpublish_is_protected($form['nid']['#value'])) {
       $form['options']['status']['#default_value'] = 1;
-      $form['options']['status']['#disabled'] = true;
+      $form['options']['status']['#disabled'] = TRUE;
     }
   }
+}
+
+/**
+ * Check if the node is protected.
+ *
+ * @param $nid
+ *   The node id to check.
+ *
+ * @return bool
+ *   TRUE if protected else FALSE.
+ */
+function _reol_prevent_unpublish_is_protected($nid) {
+  $nids = array_map('trim', explode(',', variable_get('reol_prevent_unpublish_nid', '')));
+  if (in_array($nid, $nids)) {
+    return TRUE;
+  }
+
+  return FALSE;
 }

--- a/sites/all/modules/reol_prevent_unpublish/reol_prevent_unpublish.module
+++ b/sites/all/modules/reol_prevent_unpublish/reol_prevent_unpublish.module
@@ -61,9 +61,6 @@ function reol_prevent_unpublish_form_alter(&$form, &$form_state, $form_id) {
  */
 function _reol_prevent_unpublish_is_protected($nid) {
   $nids = array_map('trim', explode(',', variable_get('reol_prevent_unpublish_nid', '')));
-  if (in_array($nid, $nids)) {
-    return TRUE;
-  }
 
-  return FALSE;
+  return in_array($nid, $nids);
 }

--- a/sites/all/modules/reol_prevent_unpublish/reol_prevent_unpublish.module
+++ b/sites/all/modules/reol_prevent_unpublish/reol_prevent_unpublish.module
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Prevent selected node from being unpublished.
+ */
+
+/**
+ * Implements hook_menu().
+ */
+function reol_prevent_unpublish_menu() {
+  $items = [];
+
+  $items['admin/config/ereolen/prevent'] = array(
+    'title' => 'Prevent un-publish',
+    'description' => 'Control which nodes to protected.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('reol_prevent_unpublish_settings_form'),
+    'access arguments' => array('administer content'),
+    'file' => 'includes/reol_prevent_unpublish.admin.inc',
+  );
+
+  return $items;
+}
+
+/**
+ * Implements hook_node_presave().
+ *
+ * Ensure no one can unpublish the nodes in any-way.
+ */
+function reol_prevent_unpublish_node_presave($node) {
+  if (0 === $node->status) {
+    $nids = array_map('trim', explode(',', variable_get('reol_prevent_unpublish_nid', '')));
+    if (in_array($node->nid, $nids)) {
+      // Nid is found in array, so publish it.
+      $node->status = 1;
+    }
+  }
+}
+
+/**
+ * Implements hook_node_load().
+ *
+ * Disabled the node unpublish checkbox in node edit form.
+ */
+function reol_prevent_unpublish_form_alter(&$form, &$form_state, $form_id) {
+  if (strpos($form_id, '_node_form') !== FALSE) {
+    $nids = array_map('trim', explode(',', variable_get('reol_prevent_unpublish_nid', '')));
+    if (isset($form['nid']['#value']) && in_array($form['nid']['#value'], $nids)) {
+      $form['options']['status']['#default_value'] = 1;
+      $form['options']['status']['#disabled'] = true;
+    }
+  }
+}


### PR DESCRIPTION
Ticket: https://jira.itkdev.dk/browse/ER-1072

1. Always set node `status = 1` for nodes in prevent list on node save (to lock it down).

2. Prevent un-check in node edit form (to show user that is can not be unpublished).
![Screenshot 2021-01-18 at 14 27 41](https://user-images.githubusercontent.com/111397/104921834-28d7d080-599a-11eb-8f6b-aa7eb6355893.png)

3. Very simple administrative UI.
![Screenshot 2021-01-18 at 14 28 27](https://user-images.githubusercontent.com/111397/104921886-3f7e2780-599a-11eb-80a5-6a40b1f04006.png)

