### PR TITLE
SUPP0RT-379: Disallowed indexing of login paths

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -78,6 +78,9 @@ Disallow: /user/register/
 Disallow: /user/password/
 Disallow: /user/login/
 Disallow: /user/logout/
+# Login
+Disallow: /login/ajax
+Disallow: /login/nojs
 # Paths (no clean URLs)
 Disallow: /?q=admin/
 Disallow: /?q=comment/reply/


### PR DESCRIPTION
https://jira.itkdev.dk/browse/SUPP0RT-379

Google (and possibly others search engines) has managed to index some login paths.

