### PR TITLE
ER-1296: Fixed article summary length

### DIFF
--- a/sites/all/modules/ereol_article/ereol_article.features.field_instance.inc
+++ b/sites/all/modules/ereol_article/ereol_article.features.field_instance.inc
@@ -44,7 +44,7 @@ function ereol_article_field_default_field_instances() {
         'label' => 'hidden',
         'module' => 'text',
         'settings' => array(
-          'trim_length' => 600,
+          'trim_length' => 120,
         ),
         'type' => 'text_summary_or_trimmed',
         'weight' => 1,


### PR DESCRIPTION
https://jira.itkdev.dk/browse/ER-1296

Sets article summary trim length to 120.
