### PR TITLE
ER-1193: Added info on current number of loans

### DIFF
--- a/sites/all/modules/reol_frontend/plugins/content_types/library_info.inc
+++ b/sites/all/modules/reol_frontend/plugins/content_types/library_info.inc
@@ -37,6 +37,16 @@ function library_info_content_type_render($subtype, $conf, $panel_args, $context
   );
   $extra_link = url('search/ting/*', array('query' => $query));
 
+  // Build information on current number of loans by material type.
+  global $user;
+  require_once drupal_get_path('module', 'publizon').'/includes/publizon.loan.inc';
+  $loans = publizon_loan_list($user);
+
+  $loans_by_type = [];
+  foreach ($loans as $loan) {
+    $loans_by_type[$loan->publizon_type] = ($loans_by_type[$loan->publizon_type] ?? 0) + 1;
+  }
+
   $variables = array(
     // Quotas.
     'max_ebook_loans' => $library->maxEbookLoans,
@@ -45,8 +55,14 @@ function library_info_content_type_render($subtype, $conf, $panel_args, $context
     'max_audiobook_reservations' => $library->maxAudiobookReservations,
     'extra_link' => $extra_link,
     // Legacy texts.
-    'max_ebook_loans_text' => t('You are allowed to loan @loans e-books simultaneously.', array('@loans' => $library->maxEbookLoans)),
-    'max_audiobook_loans_text' => t('You are allowed to loan @loans audiobooks simultaneously.', array('@loans' => $library->maxAudiobookLoans)),
+    'max_ebook_loans_text' => t('You have loaned @number_of_loans out of @max_number_of_loans e-books.', array(
+      '@number_of_loans' => $loans_by_type['ebog'] ?? 0,
+      '@max_number_of_loans' => $library->maxEbookLoans,
+    )),
+    'max_audiobook_loans_text' => t('You have loaned @number_of_loans out of @max_number_of_loans audiobooks.', array(
+      '@number_of_loans' => $loans_by_type['lydbog (net)'] ?? 0,
+      '@max_number_of_loans' => $library->maxAudiobookLoans,
+    )),
     'max_reservations_text' => t('You are allowed to reserve @reservations titles simultaneously.', array('@reservations' => $library->maxEbookReservations)),
     'extra_info_text' => t('<a href="@url">Titles exempt from quotas.</a>', array('@url' => $extra_link)),
   );

--- a/sites/all/modules/reol_frontend/reol_frontend.info
+++ b/sites/all/modules/reol_frontend/reol_frontend.info
@@ -19,6 +19,7 @@ dependencies[] = menu_block
 dependencies[] = options
 dependencies[] = page_manager
 dependencies[] = panels
+dependencies[] = publizon
 dependencies[] = pm_existing_pages
 dependencies[] = ting_infomedia
 dependencies[] = views


### PR DESCRIPTION
https://jira.itkdev.dk/browse/ER-1193

Adds info on current number of loans.

Before

<img width="332" alt="Screenshot 2022-09-07 at 15 40 00" src="https://user-images.githubusercontent.com/11267554/188893074-ca8645bf-20e8-451e-8397-25ecc1a6a90b.png">

After (missing Danish translation)

<img width="332" alt="Screenshot 2022-09-07 at 15 39 42" src="https://user-images.githubusercontent.com/11267554/188893120-d02a69cc-180a-43a7-84b9-609dd0d639b5.png">
