### PR TITLE
ER-1193: Updated display on GO

### DIFF
--- a/sites/all/modules/reol_frontend/plugins/content_types/library_info.inc
+++ b/sites/all/modules/reol_frontend/plugins/content_types/library_info.inc
@@ -48,6 +48,8 @@ function library_info_content_type_render($subtype, $conf, $panel_args, $context
   }
 
   $variables = array(
+    'ebook_loans' => $loans_by_type['ebog'] ?? 0,
+    'audiobook_loans' => $loans_by_type['lydbog (net)'] ?? 0,
     // Quotas.
     'max_ebook_loans' => $library->maxEbookLoans,
     'max_audiobook_loans' => $library->maxAudiobookLoans,

--- a/sites/all/themes/wille/templates/user/library_info.tpl.php
+++ b/sites/all/themes/wille/templates/user/library_info.tpl.php
@@ -9,19 +9,21 @@
 <div class="user-quota-info">
   <div class="user-quota-info__section">
     <div class="user-quota-info__section-inner">
-      <p><?php print t('Loans you got left:'); ?><p>
+      <p><?php print t('You have loaned'); ?><p>
       <ul>
         <li class="loans-left">
-          <div class="loans-left__amount">
-            <?php print $max_ebook_loans; ?>
+          <div class="loans-left__amount" style="font-size: 2.2rem">
+            <?php print $ebook_loans; ?>
+            <span style="font-size: 45%; display: block"><?php print t('out of @max_loans', ['@max_loans' => $max_ebook_loans]); ?></span>
           </div>
           <div class="loans-left__type">
             <?php print t('E-books'); ?>
           </div>
         </li>
         <li class="loans-left">
-          <div class="loans-left__amount">
-            <?php print $max_audiobook_loans; ?>
+          <div class="loans-left__amount" style="font-size: 2.2rem">
+            <?php print $audiobook_loans; ?>
+            <span style="font-size: 45%; display: block"><?php print t('out of @max_loans', ['@max_loans' => $max_audiobook_loans]); ?></span>
           </div>
           <div class="loans-left__type">
             <?php print t('Audiobooks'); ?>


### PR DESCRIPTION
https://jira.itkdev.dk/browse/ER-1193

Updated display of loans and max loans on GO. Breaks all rules for how to build translatable strings with "n of m" placeholders – but it works!
