### PR TITLE
ER-1432: Municipality aliases

### DIFF
--- a/sites/all/modules/publizon/includes/publizon.admin.inc
+++ b/sites/all/modules/publizon/includes/publizon.admin.inc
@@ -222,6 +222,15 @@ function publizon_settings_form(array $form, array &$form_state) {
     $i++;
   }
 
+  $municipality_aliases = variable_get('publizon_municipality_aliases', array());
+
+  $form['publizon']['municipality_aliases'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Municipality aliases'),
+    '#description' => t("Format: <code>«municipality id»: «alias id»</code>; one pr. line, e.g. <pre>451: 87\n42: 123</pre>"),
+    '#default_value' => _publizon_admin_serialize_municipality_aliases($municipality_aliases),
+  );
+
   // Add messages fieldset.
   $form['publizon']['error_messages'] = array(
     '#type' => 'fieldset',
@@ -503,6 +512,9 @@ function publizon_settings_form_submit(array $form, array &$form_state) {
 
   variable_set('publizon_error_messages', $error_messages);
 
+  $municipality_aliases = _publizon_admin_deserialize_municipality_aliases($form_state['values']['publizon']['municipality_aliases']);
+  variable_set('publizon_municipality_aliases', $municipality_aliases);
+
   drupal_set_message(t('The configuration options have been saved.'));
 }
 
@@ -567,4 +579,65 @@ function publizon_admin_settings_form_submit(array $form, array &$form_state) {
       )
     )
   );
+}
+
+/**
+ * Serialize municipality aliases.
+ *
+ * Example:
+ *
+ *   [
+ *     87 => 42,
+ *    123 => 256,
+ *   ]
+ *
+ * is serialized as
+ *
+ *   87: 42
+ *   123: 256
+ *
+ * @param array $aliases
+ *   The aliases (map from id to alias).
+ *
+ * @return string
+ *   The serialized aliases.
+ */
+function _publizon_admin_serialize_municipality_aliases(array $aliases) {
+  $items = [];
+
+  foreach ($aliases as $id => $alias) {
+    $items[] = sprintf('%s: %s', $id, $alias);
+  }
+
+  return implode(PHP_EOL, $items);
+}
+
+/**
+ * Deserialize municipality aliases.
+ *
+ * Example:
+ *
+ *   87: 42
+ *   123: 256
+ *   87: 23
+ *
+ * (note duplicated key 87) is deserialized as
+ *
+ *   [
+ *     87 => 23,
+ *    123 => 256,
+ *   ]
+ *
+ * @param string $serialized
+ *   The serialized aliases.
+ *
+ * @return array
+ *   The deserialized aliases.
+ */
+function _publizon_admin_deserialize_municipality_aliases(string $serialized) {
+  if (preg_match_all('/^\s*(?<id>\d+)\s*:\s*(?<alias>\d+)\s*$/m', $serialized, $matches)) {
+    return array_combine($matches['id'], $matches['alias']);
+  }
+
+  return [];
 }

--- a/sites/all/modules/publizon/includes/publizon.auth.inc
+++ b/sites/all/modules/publizon/includes/publizon.auth.inc
@@ -16,6 +16,12 @@
  */
 function publizon_auth_single_sign_on($name, array $extra) {
   $type = empty($extra['attributes']['municipality']) ? 'unilogin' : 'municipality';
+
+  $municipality_aliases = variable_get('publizon_municipality_aliases', []);
+  if ('municipality' === $type && isset($municipality_aliases[$extra['attributes'][$type]])) {
+    $extra['attributes'][$type] = $municipality_aliases[$extra['attributes'][$type]];
+  }
+
   $lib = publizon_filter_libraries_list(array($extra['attributes'][$type]), $type);
   if (empty($lib)) {
     throw new DingProviderUserAuthFailure('Unable to find retailer id');


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/ER-1432

#### Description

Makes it possible to alias a municipality to another municipality. The aliases can be edited with `drush`:

```sh
# Map municipality Fanø (563) to Esbjerg (561)
drush variable-set publizon_municipality_aliases --format=json '{"563": "561"}'
```

or on `/admin/config/ding/provider/publizon` (cf. screenshot).

#### Screenshot of the result

![Screen Shot 2022-12-21 at 21 46 36](https://user-images.githubusercontent.com/11267554/208999904-db7a1d87-b212-4100-b758-3b8d46e5f430.png)

#### Checklist

- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change
should be exempt from the list.

#### Additional comments or questions

This is a hack!
