### PR TITLE
SUPP0RT-836: Handled media type "e-bog"

### DIFF
--- a/sites/all/modules/reol_base/reol_base.module
+++ b/sites/all/modules/reol_base/reol_base.module
@@ -804,6 +804,11 @@ function _reol_base_get_types() {
         'base' => 'audiobook',
         'ext_name' => 'lyd (net)',
       ),
+      // Handle “e-bog” as “ebook”.
+      'e-bog' => array(
+        'base' => 'ebook',
+        'ext_name' => 'e-bog',
+      ),
     );
 
     $types = $base_types;


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/SUPP0RT-836

#### Description

Some items in Brønden have only a single media type, e.g.

```xml
<dc:type xsi:type="dkdcplus:BibDK-Type">E-bog</dc:type>
```

whereas others (most?) have more media types, e.g.

```xml
<dc:type xsi:type="dkdcplus:BibDK-Type">Billedbog (net)</dc:type>
<dc:type xsi:type="dkdcplus:BibDK-Type">E-bog</dc:type>
```

This change adds "E-bog" to the types defined in [_reol_base_get_types](https://github.com/eReolen/base/blob/develop/sites/all/modules/reol_base/reol_base.module#L737-L822).

See https://jira.itkdev.dk/browse/SUPP0RT-836?focusedCommentId=44811&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-44811 for further details.

#### Checklist

- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change
should be exempt from the list.

