### PR TITLE
ER-1425: Added agencytype=folk to login url

### DIFF
--- a/profiles/ding2/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/profiles/ding2/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -255,6 +255,7 @@ function ding_adgangsplatformen_get_configuration() {
     'urlLogout' => 'https://login.bib.dk/logout/',
     'singleLogout' => TRUE,
     'automaticallyAgency' => TRUE,
+    'agencytype' => TRUE,
     'singleLogoutOrigin' => 'https://login.bib.dk/',
     'revoke' => 'https://login.bib.dk/oauth/revoke',
   ];
@@ -294,6 +295,11 @@ function ding_adgangsplatformen_generate_login_url($destination = '') {
   // Check if an identity provider have been set in the request.
   if (!empty($_REQUEST['idp'])) {
     $authorization_url .= '&idp=' . $_REQUEST['idp'];
+  }
+
+  // Filter on agency type (only show "folkebibliotekeren).
+  if ($configuration['agencytype']) {
+    $authorization_url .= '&agencytype=folk';
   }
 
   // Add agency to the URL.

--- a/profiles/ding2/modules/ding_adgangsplatformen/includes/ding_adgangsplatformen.admin.inc
+++ b/profiles/ding2/modules/ding_adgangsplatformen/includes/ding_adgangsplatformen.admin.inc
@@ -92,6 +92,13 @@ function ding_adgangsplatformen_admin_settings_form($form, &$form_state) {
     '#default_value' => $default['automaticallyAgency'],
   );
 
+  $form['ding_adgangsplatformen_settings']['agencytype'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Only show "folkebiblioteker" in library selection dropdown (agencytype=folk)'),
+    '#return_value' => TRUE,
+    '#default_value' => $default['agencytype'] ?? TRUE,
+  );
+
   $form['ding_adgangsplatformen_settings']['singleLogoutOrigin'] = array(
     '#type' => 'textfield',
     '#title' => t('Iframe url'),


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/ER-1425

#### Description

Added agency type to single signon to only show "folkebiblioteker" in the library selection dropdown.

#### Screenshot of the result

![Screenshot from 2023-01-30 12-37-08](https://user-images.githubusercontent.com/111397/215467960-15046a26-6f42-4b5a-8068-731fd587dda0.png)

#### Checklist

- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change
should be exempt from the list.

#### Additional comments or questions

N/A
