### PR TITLE
ER-1444: Confirm profile data

### DIFF
--- a/sites/all/modules/publizon/publizon.features.field_base.inc
+++ b/sites/all/modules/publizon/publizon.features.field_base.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * publizon.features.field_base.inc
@@ -27,6 +28,24 @@ function publizon_field_default_field_bases() {
     'type' => 'email',
   );
 
+  // Exported field_base: 'field_email_confirm'.
+  $field_bases['field_email_confirm'] = array(
+    'active' => 1,
+    'cardinality' => 1,
+    'deleted' => 0,
+    'entity_id_type' => NULL,
+    'entity_types' => array(),
+    'field_name' => 'field_email_confirm',
+    'indexes' => array(),
+    'locked' => 0,
+    'module' => 'email',
+    'settings' => array(
+      'profile2_private' => 0,
+    ),
+    'translatable' => 0,
+    'type' => 'email',
+  );
+
   // Exported field_base: 'field_phone'.
   $field_bases['field_phone'] = array(
     'active' => 1,
@@ -39,6 +58,24 @@ function publizon_field_default_field_bases() {
     'module' => 'number',
     'settings' => array(
       'profile2_private' => 1,
+    ),
+    'translatable' => 0,
+    'type' => 'number_integer',
+  );
+
+  // Exported field_base: 'field_phone_confirm'.
+  $field_bases['field_phone_confirm'] = array(
+    'active' => 1,
+    'cardinality' => 1,
+    'deleted' => 0,
+    'entity_id_type' => NULL,
+    'entity_types' => array(),
+    'field_name' => 'field_phone_confirm',
+    'indexes' => array(),
+    'locked' => 0,
+    'module' => 'number',
+    'settings' => array(
+      'profile2_private' => 0,
     ),
     'translatable' => 0,
     'type' => 'number_integer',

--- a/sites/all/modules/publizon/publizon.features.field_instance.inc
+++ b/sites/all/modules/publizon/publizon.features.field_instance.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * publizon.features.field_instance.inc
@@ -39,6 +40,39 @@ function publizon_field_default_field_instances() {
         'size' => 60,
       ),
       'type' => 'email_textfield',
+      'weight' => 2,
+    ),
+  );
+
+  // Exported field_instance: 'profile2-provider_publizon-field_email_confirm'.
+  $field_instances['profile2-provider_publizon-field_email_confirm'] = array(
+    'bundle' => 'provider_publizon',
+    'default_value' => NULL,
+    'deleted' => 0,
+    'description' => 'Confirm your email address',
+    'display' => array(
+      'default' => array(
+        'label' => 'above',
+        'module' => 'email',
+        'settings' => array(),
+        'type' => 'email_default',
+        'weight' => 3,
+      ),
+    ),
+    'entity_type' => 'profile2',
+    'field_name' => 'field_email_confirm',
+    'label' => 'Email (confirm)',
+    'required' => 0,
+    'settings' => array(
+      'user_register_form' => FALSE,
+    ),
+    'widget' => array(
+      'active' => 1,
+      'module' => 'email',
+      'settings' => array(
+        'size' => 60,
+      ),
+      'type' => 'email_textfield',
       'weight' => 3,
     ),
   );
@@ -60,7 +94,7 @@ function publizon_field_default_field_instances() {
           'thousand_separator' => ' ',
         ),
         'type' => 'number_integer',
-        'weight' => 1,
+        'weight' => 0,
       ),
     ),
     'entity_type' => 'profile2',
@@ -79,15 +113,58 @@ function publizon_field_default_field_instances() {
       'module' => 'number',
       'settings' => array(),
       'type' => 'number',
-      'weight' => 2,
+      'weight' => 0,
+    ),
+  );
+
+  // Exported field_instance: 'profile2-provider_publizon-field_phone_confirm'.
+  $field_instances['profile2-provider_publizon-field_phone_confirm'] = array(
+    'bundle' => 'provider_publizon',
+    'default_value' => NULL,
+    'deleted' => 0,
+    'description' => 'Confirm your phone number',
+    'display' => array(
+      'default' => array(
+        'label' => 'above',
+        'module' => 'number',
+        'settings' => array(
+          'decimal_separator' => '.',
+          'prefix_suffix' => 1,
+          'scale' => 0,
+          'thousand_separator' => ' ',
+        ),
+        'type' => 'number_integer',
+        'weight' => 1,
+      ),
+    ),
+    'entity_type' => 'profile2',
+    'field_name' => 'field_phone_confirm',
+    'label' => 'Phone (confirm)',
+    'required' => 0,
+    'settings' => array(
+      'max' => 99999999,
+      'min' => 10000000,
+      'prefix' => '+45',
+      'suffix' => '',
+      'user_register_form' => FALSE,
+    ),
+    'widget' => array(
+      'active' => 0,
+      'module' => 'number',
+      'settings' => array(),
+      'type' => 'number',
+      'weight' => 1,
     ),
   );
 
   // Translatables
   // Included for use with string extractors like potx.
+  t('Confirm your email address');
+  t('Confirm your phone number');
   t('Email');
+  t('Email (confirm)');
   t('Phone');
-  t('Your friendly id for using in support requests.');
+  t('Phone (confirm)');
 
   return $field_instances;
 }

--- a/sites/all/modules/publizon/publizon.features.inc
+++ b/sites/all/modules/publizon/publizon.features.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * publizon.features.inc

--- a/sites/all/modules/publizon/publizon.info
+++ b/sites/all/modules/publizon/publizon.info
@@ -19,9 +19,13 @@ dependencies[] = ting_covers
 features[ctools][] = strongarm:strongarm:1
 features[features_api][] = api:2
 features[field_base][] = field_email
+features[field_base][] = field_email_confirm
 features[field_base][] = field_phone
+features[field_base][] = field_phone_confirm
 features[field_instance][] = profile2-provider_publizon-field_email
+features[field_instance][] = profile2-provider_publizon-field_email_confirm
 features[field_instance][] = profile2-provider_publizon-field_phone
+features[field_instance][] = profile2-provider_publizon-field_phone_confirm
 features[profile2_type][] = provider_publizon
 features[variable][] = ting_reservable_types
 files[] = publizon.classes.inc
@@ -29,19 +33,16 @@ files[] = lib/PublizonClient.class.inc
 files[] = lib/PublizonLogger.class.inc
 files[] = lib/PublizonNanoSoapClient.class.inc
 files[] = lib/Publizon.class.inc
-; Client classes.
 files[] = lib/client/PublizonLoanClient.class.inc
 files[] = lib/client/PublizonReservationClient.class.inc
 files[] = lib/client/PublizonChecklistClient.class.inc
 files[] = lib/client/PublizonProductClient.class.inc
 files[] = lib/client/PublizonLibraryClient.class.inc
 files[] = lib/client/PublizonUserClient.class.inc
-; Storage classes.
 files[] = lib/storage/PublizonLoan.class.inc
 files[] = lib/storage/PublizonReservation.class.inc
 files[] = lib/storage/PublizonLoanStatus.class.inc
 files[] = lib/storage/PublizonChecklistItem.class.inc
 files[] = lib/storage/PublizonProduct.class.inc
 files[] = lib/storage/PublizonLibrary.class.inc
-; Exceptions
 files[] = exceptions/PublizonAuthFailureException.inc

--- a/sites/all/modules/publizon/publizon.strongarm.inc
+++ b/sites/all/modules/publizon/publizon.strongarm.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * publizon.strongarm.inc

--- a/sites/all/modules/reol_frontend/reol_frontend.module
+++ b/sites/all/modules/reol_frontend/reol_frontend.module
@@ -295,6 +295,19 @@ function reol_frontend_form_profile2_edit_provider_publizon_form_alter(&$form, &
   unset($form['profile_provider_publizon']['field_phone_confirm'][LANGUAGE_NONE][0]['value']['#default_value']);
   unset($form['profile_provider_publizon']['field_email_confirm'][LANGUAGE_NONE][0]['email']['#default_value']);
 
+  // Use states to show confirm fields only when needed.
+  $form['profile_provider_publizon']['field_phone_confirm']['#states'] = array(
+    'visible' => array(
+      ':input[name="profile_provider_publizon[field_phone][und][0][value]"]' => array('empty' => FALSE),
+    ),
+  );
+
+  $form['profile_provider_publizon']['field_email_confirm']['#states'] = array(
+    'visible' => array(
+      ':input[name="profile_provider_publizon[field_email][und][0][email]"]' => array('empty' => FALSE),
+    ),
+  );
+
   $form['#validate'][] = '_reol_frontend_profile2_validate';
 }
 

--- a/sites/all/modules/reol_frontend/reol_frontend.module
+++ b/sites/all/modules/reol_frontend/reol_frontend.module
@@ -310,7 +310,7 @@ function reol_frontend_form_profile2_edit_provider_publizon_form_alter(&$form, &
  */
 function _reol_frontend_profile2_validate(array $form, array &$form_state) {
   $phone_value = trim($form_state['values']['profile_provider_publizon']['field_phone'][LANGUAGE_NONE][0]['value'] ?? '');
-  if (NULL !== $phone_value) {
+  if (!empty($phone_value)) {
     $phone_value_confirm = trim($form_state['values']['profile_provider_publizon']['field_phone_confirm'][LANGUAGE_NONE][0]['value'] ?? '');
     if ($phone_value_confirm !== $phone_value) {
       form_set_error('profile_provider_publizon][field_phone_confirm', t('Please confirm your phone number'));

--- a/sites/all/modules/reol_frontend/reol_frontend.module
+++ b/sites/all/modules/reol_frontend/reol_frontend.module
@@ -281,6 +281,49 @@ function reol_frontend_form_profile2_edit_provider_publizon_form_alter(&$form, &
 
   // Hide sms fee.
   $form['ding_user_fee_sms']['#access'] = FALSE;
+
+  // Add message about confirming values right under “Support id”.
+  $message = variable_get('ereol_profile_confirm_message');
+  if (!empty($message['value'])) {
+    $form['ereol_profile_confirm_message'] = array(
+      '#markup' => '<div class="profile-confirm-message">' . $message['value'] . '</div>',
+      '#weight' => -49,
+    );
+  }
+
+  // Unset default values to force user to confirm values when saving.
+  unset($form['profile_provider_publizon']['field_phone_confirm'][LANGUAGE_NONE][0]['value']['#default_value']);
+  unset($form['profile_provider_publizon']['field_email_confirm'][LANGUAGE_NONE][0]['email']['#default_value']);
+
+  $form['#validate'][] = '_reol_frontend_profile2_validate';
+}
+
+/**
+ * Validation function for profile2_edit_provider_publizon form.
+ *
+ * Validates that phone and email are confirmed if set.
+ *
+ * @param array $form
+ *   The form.
+ * @param array $form_state
+ *   The form state.
+ */
+function _reol_frontend_profile2_validate(array $form, array &$form_state) {
+  $phone_value = trim($form_state['values']['profile_provider_publizon']['field_phone'][LANGUAGE_NONE][0]['value'] ?? '');
+  if (NULL !== $phone_value) {
+    $phone_value_confirm = trim($form_state['values']['profile_provider_publizon']['field_phone_confirm'][LANGUAGE_NONE][0]['value'] ?? '');
+    if ($phone_value_confirm !== $phone_value) {
+      form_set_error('profile_provider_publizon][field_phone_confirm', t('Please confirm your phone number'));
+    }
+  }
+
+  $email_value = trim($form_state['values']['profile_provider_publizon']['field_email'][LANGUAGE_NONE][0]['email'] ?? '');
+  if (!empty($email_value)) {
+    $email_value_confirm = trim($form_state['values']['profile_provider_publizon']['field_email_confirm'][LANGUAGE_NONE][0]['email'] ?? '');
+    if ($email_value_confirm !== $email_value) {
+      form_set_error('profile_provider_publizon][field_email_confirm', t('Please confirm your email address'));
+    }
+  }
 }
 
 /**

--- a/sites/all/modules/reol_loan/reol_loan.module
+++ b/sites/all/modules/reol_loan/reol_loan.module
@@ -330,6 +330,15 @@ function reol_loan_form_user_admin_settings_alter(&$form, &$form_state, $form_id
     '#default_value' => isset($loan_text['value']) ? $loan_text['value'] : '',
     '#description' => t('Text to display in the loan section of the user page.'),
   );
+
+  $message = variable_get('ereol_profile_confirm_message');
+  $form['ereol_user']['ereol_profile_confirm_message'] = array(
+    '#type' => 'text_format',
+    '#title' => t('Profile confirm message'),
+    '#format' => 'ding_wysiwyg',
+    '#default_value' => $message['value'] ?? '',
+    '#description' => t('Message to diplay on user profile page.'),
+  );
 }
 
 /**


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/ER-1444

#### Description

Adds confirm fields for phone and email on user profile and validates that values are confirmed correctly.

A message about why the confirmation is need can be set on `/admin/config/people/accounts` » Profile confirm message

#### Screenshot of the result

(Missing translation of error message)

<img width="1149" alt="Screenshot 2023-05-10 at 23 02 36" src="https://github.com/eReolen/base/assets/11267554/bf054e9d-7485-41b5-b209-ba63e7d95c7e">

#### Checklist

- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change
should be exempt from the list.

