### PR TITLE
ER-1359: Remove redirect from singleton collection to object

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Android install prompt is not displayed (https://www.drupal.org/node/3047715)
 * Don't exclude "dkdcplus:DBCO" subjects (opensearch-dkdcplus-DBCO.patch)
 * Update to image_resize_filter 1.16 (ding2-make-image_resize_filter.patch)
 * Disallow: /content/unilogin in robots.txt (robots-content-unilogin.patch)
+* Do not redirect from `/ting/collection` to `/ting/object` when collection contains only a single element (do_not_redirect_from_collection_to_object.patch)
 
 # Docker
 This repository comes with an `docker-compose.yml` to run the stack in

--- a/profiles/ding2/modules/ting/plugins/content_types/ting_collection.inc
+++ b/profiles/ding2/modules/ting/plugins/content_types/ting_collection.inc
@@ -21,11 +21,6 @@ function ting_collection_content_type_render($subtype, $conf, $args, $context) {
   $block = new stdClass();
   $object = isset($context->data) ? ($context->data) : NULL;
   if ($object instanceOf TingCollection) {
-    if (count($object->getEntities()) < 2) {
-      $uri = entity_uri('ting_object', $object);
-      drupal_goto($uri['path'], $uri['options']);
-    }
-
     // Add search overlay trigger.
     drupal_add_js(drupal_get_path('module', 'ting') . '/js/ting.js');
 

--- a/profiles/ding2/modules/ting/ting.module
+++ b/profiles/ding2/modules/ting/ting.module
@@ -441,10 +441,6 @@ function ting_object_page_view($object) {
  * Page callback: Display a ting collection.
  */
 function ting_collection_page_view($object) {
-  if (count($object->getEntities()) < 2) {
-    $uri = entity_uri('ting_object', $object);
-    drupal_goto($uri['path'], $uri['options']);
-  }
   return ting_collection_view($object);
 }
 

--- a/sites/all/patches/do_not_redirect_from_collection_to_object.patch
+++ b/sites/all/patches/do_not_redirect_from_collection_to_object.patch
@@ -1,0 +1,31 @@
+diff --git a/profiles/ding2/modules/ting/plugins/content_types/ting_collection.inc b/profiles/ding2/modules/ting/plugins/content_types/ting_collection.inc
+index c019d1dd9..67d158b0f 100644
+--- a/profiles/ding2/modules/ting/plugins/content_types/ting_collection.inc
++++ b/profiles/ding2/modules/ting/plugins/content_types/ting_collection.inc
+@@ -21,11 +21,6 @@ function ting_collection_content_type_render($subtype, $conf, $args, $context) {
+   $block = new stdClass();
+   $object = isset($context->data) ? ($context->data) : NULL;
+   if ($object instanceOf TingCollection) {
+-    if (count($object->getEntities()) < 2) {
+-      $uri = entity_uri('ting_object', $object);
+-      drupal_goto($uri['path'], $uri['options']);
+-    }
+-
+     // Add search overlay trigger.
+     drupal_add_js(drupal_get_path('module', 'ting') . '/js/ting.js');
+ 
+diff --git a/profiles/ding2/modules/ting/ting.module b/profiles/ding2/modules/ting/ting.module
+index f7d060403..f813dd1c7 100644
+--- a/profiles/ding2/modules/ting/ting.module
++++ b/profiles/ding2/modules/ting/ting.module
+@@ -441,10 +441,6 @@ function ting_object_page_view($object) {
+  * Page callback: Display a ting collection.
+  */
+ function ting_collection_page_view($object) {
+-  if (count($object->getEntities()) < 2) {
+-    $uri = entity_uri('ting_object', $object);
+-    drupal_goto($uri['path'], $uri['options']);
+-  }
+   return ting_collection_view($object);
+ }
+ 


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/ER-1359

#### Description

Removes redirect from `/ting/collection/identifier` to `/ting/object/identifier` when the collection contains only a single element.

#### Checklist

- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change
should be exempt from the list.
