### PR TITLE
ER-1491: Remove “out of” stuff from loans info

### DIFF
--- a/sites/all/modules/reol_loan/reol_loan.module
+++ b/sites/all/modules/reol_loan/reol_loan.module
@@ -350,13 +350,21 @@ function reol_loan_panels_pane_content_alter($content, $pane, $args, $contexts) 
   if ($pane->type == 'loans') {
     if ($pane->subtype == 'loans') {
       if (!empty($content->content)) {
-        if (isset(variable_get('ereol_loan_text')['value'])) {
+        $loan_text = variable_get('ereol_loan_text');
+        if (!empty($loan_text['value'])) {
           // Add text to top of loan block.
           $content->content = array(
             'ereol_loan_text' => array(
-              '#markup' => '<div>' . variable_get('ereol_loan_text')['value'] . '</div>',
+              '#prefix' => '<div>',
+              '#markup' => $loan_text['value'],
+              '#suffix' => '</div>',
             ),
-          ) + $content->content;
+            'content' => array(
+              '#prefix' => '<div>',
+              '#markup' => render($content->content),
+              '#suffix' => '</div>',
+            ),
+          );
         }
       }
     }

--- a/sites/all/themes/wille/templates/user/library_info.tpl.php
+++ b/sites/all/themes/wille/templates/user/library_info.tpl.php
@@ -12,18 +12,16 @@
       <p><?php print t('You have loaned'); ?><p>
       <ul>
         <li class="loans-left">
-          <div class="loans-left__amount" style="font-size: 2.2rem">
+          <div class="loans-left__amount">
             <?php print $ebook_loans; ?>
-            <span style="font-size: 45%; display: block"><?php print t('out of @max_loans', ['@max_loans' => $max_ebook_loans]); ?></span>
           </div>
           <div class="loans-left__type">
             <?php print t('E-books'); ?>
           </div>
         </li>
         <li class="loans-left">
-          <div class="loans-left__amount" style="font-size: 2.2rem">
+          <div class="loans-left__amount">
             <?php print $audiobook_loans; ?>
-            <span style="font-size: 45%; display: block"><?php print t('out of @max_loans', ['@max_loans' => $max_audiobook_loans]); ?></span>
           </div>
           <div class="loans-left__type">
             <?php print t('Audiobooks'); ?>


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/ER-1491

#### Description

- Removes “out of” stuff from loans info (see screenshots)
- Fixes handling of ereol_loan_text

#### Screenshot of the result

Before:
![ereolengo dk_user](https://github.com/eReolen/base/assets/11267554/b6a65f17-2fa1-4b2a-abcd-e3c0792c6c99)

After:
![stg ereolengo itkdev dk_user](https://github.com/eReolen/base/assets/11267554/fa90f66c-5175-42d1-bcd0-a39b8a8c4302)

#### Checklist

- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
