### PR TITLE
Show submit button only if phone or email notification is visible

### DIFF
--- a/sites/all/modules/publizon/publizon.module
+++ b/sites/all/modules/publizon/publizon.module
@@ -396,6 +396,15 @@ function publizon_form_ding_reservation_reserve_form_alter(array &$form, array &
   );
   $form['publizon']['field_email']['#weight'] = 30;
 
+  // Show submit button only if phone or email notification is visible.
+  $form['submit']['#states'] = array(
+    'visible' => array(
+      [$form['publizon']['field_phone']['#states']['visible']],
+      'or',
+      [$form['publizon']['field_email']['#states']['visible']],
+    ),
+  );
+
   // Add phone confirm field.
   $form['publizon'] += reol_base_get_field_form('profile2', 'provider_publizon', 'field_email_confirm', $profile, $form, $form_state);
   $form['publizon']['field_email_confirm']['#states'] = $form['publizon']['field_email']['#states'];


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/233

#### Description

Shows submit button only if phone or email notification is visible.

#### Screenshot of the result

None selected:

![Screen Shot 2024-01-05 at 12 38 23](https://github.com/eReolen/base/assets/11267554/6f1cb98c-2c4a-43b1-8e52-d1bf364a306c)

Phone notification selected:

![Screen Shot 2024-01-05 at 12 38 48](https://github.com/eReolen/base/assets/11267554/1c99810a-9089-49e6-adfe-006d051d6f52)

Email notification selected:

![Screen Shot 2024-01-05 at 12 38 56](https://github.com/eReolen/base/assets/11267554/43583210-2123-461b-94e4-52dc10c3f9eb)

Both selected:

![Screen Shot 2024-01-05 at 12 39 13](https://github.com/eReolen/base/assets/11267554/08f3e04a-577d-4c8c-8bd0-f89df2a4b537)



#### Checklist

- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

